### PR TITLE
Reconfigure Spark & Yarn configuration to use less memory per Node / OOM issue fix

### DIFF
--- a/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-6.26.43.yml
+++ b/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-6.26.43.yml
@@ -68,12 +68,12 @@ all:
             spark.driver.cores                       5
             spark.driver.maxResultSize          20480m
 
-            spark.executor.memory                7168m
-            spark.executor.memoryOverhead         1024
+            spark.executor.memory                8192m
+            spark.executor.memoryOverhead         819m
             spark.executor.cores                     5
             #spark.executor.instances               30
 
-            spark.default.parallelism              300
+            #spark.default.parallelism              300
             #spark.sql.shuffle.partitions          300
 
             # YARN Application Master settings
@@ -86,7 +86,7 @@ all:
              # spark.executor.instances from Cheatsheet
             spark.dynamicAllocation.maxExecutors     30
              # maxExecutors / 2
-            spark.dynamicAllocation.initialExecutors          15
+            spark.dynamicAllocation.initialExecutors          1
             spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
             spark.dynamicAllocation.executorIdleTimeout       60s
             spark.sql.execution.arrow.pyspark.enabled            true

--- a/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-6.26.43.yml
+++ b/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-6.26.43.yml
@@ -43,7 +43,7 @@ all:
 
         # Calculated limits
         spminmem: 1024
-        spmaxmem: "{{workermemory - 1024}}"
+        spmaxmem: "{{workermemory - 8192}}"
 
         spmincores: 1
         spmaxcores: "{{workercores}}"

--- a/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-6.26.43.yml
+++ b/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-6.26.43.yml
@@ -46,7 +46,7 @@ all:
         spmaxmem: "{{workermemory - 8192}}"
 
         spmincores: 1
-        spmaxcores: "{{workercores}}"
+        spmaxcores: "{{workercores - 1}}"
 
         sparkconfig: |
 

--- a/notes/stv/20220906-debug-memory-01.txt
+++ b/notes/stv/20220906-debug-memory-01.txt
@@ -1,0 +1,389 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+# -----------------------------------------------
+# Run new deploy with same configuration as live
+# zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Create test users.
+#[root@ansibler]
+
+ source /deployments/zeppelin/bin/create-user-tools.sh
+
+ import-test-users
+
+# -------------------------------------------------------------------------------
+# Login and import the example notebook that causes the errors mentioned by Nigel
+
+# Notebook: Work in progress with Gaia XP spectra (Copied from Live deploy)
+
+# Errors: Notebook gets failed tasks, and eventually fails for the full dataset
+# If selecting a subset (10%) the notebook completes, but with failed tasks
+# [root@ansibler]
+
+
+
+
+# -------------------------------------------------------------------------------
+# Manually Edit notebook, modify cell that selects a subset
+# Remove Mod so that we get the full dataset
+
+%pyspark
+
+# select a template for the search, e.g. Proxima Cen
+#sid = 5853498713190525696 # Proxima Cen
+sid = 2585856120791459584 # HIP 7585 (Solar twin)
+template_df = spark.sql('SELECT * FROM xp_continuous_mean_spectrum WHERE source_id = %d'%(sid))
+#spark.sql('SELECT xp.*, g.parallax FROM xp_sampled_mean_spectrum AS xp INNER JOIN gaia_source AS g ON g.source_id = xp.source_id WHERE g.source_id = %d'%(sid))
+
+# grab the template parallax
+#template_parallax = template_df.collect()[0]['parallax']
+
+# define a query over the entire dataset, restricting to low reddening for simplicity
+query = 'SELECT xp.*  ' + \
+        'FROM xp_continuous_mean_spectrum AS xp INNER JOIN gaia_source AS g ON g.source_id = xp.source_id ' + \
+        'WHERE g.ag_gspphot < 0.1'
+        
+# -----------------------------------------------
+# Run Cell That takes a while to complete / Fails
+
+
+%pyspark
+#similar_df.count()
+
+# collect/cash stats to the head for plotting in the next cell - this actually actions the full workflow on the Spark cluster
+stats_pdf = similar_df.select('p_xp_similar').toPandas()
+# benchmarks: 1 in 10000 in 45min 21sec; no failed tasks
+#             1 in 1000  in 45min 21sec; ditto
+#             1 in 10    in 46min 57sec; successful completion albeit with 10 failed tasks 
+
+
+Took 20 mins
+
+# Notebook output:
+
+/opt/spark/python/pyspark/sql/pandas/conversion.py:137: UserWarning: toPandas attempted Arrow optimization because 'spark.sql.execution.arrow.pyspark.enabled' is set to true, but has reached the error below and can not continue. Note that 'spark.sql.execution.arrow.pyspark.fallback.enabled' does not have an effect on failures in the middle of computation.
+  An error occurred while calling o255.getResult.
+: org.apache.spark.SparkException: Exception thrown in awaitResult: 
+	at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:301)
+	at org.apache.spark.security.SocketAuthServer.getResult(SocketAuthServer.scala:97)
+	at org.apache.spark.security.SocketAuthServer.getResult(SocketAuthServer.scala:93)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
+	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
+	at py4j.Gateway.invoke(Gateway.java:282)
+	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
+	at py4j.commands.CallCommand.execute(CallCommand.java:79)
+	at py4j.GatewayConnection.run(GatewayConnection.java:238)
+	at java.lang.Thread.run(Thread.java:748)
+Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 99 in stage 7.0 failed 4 times, most recent failure: Lost task 99.3 in stage 7.0 (TID 8779) (worker03 executor 140): ExecutorLostFailure (executor 140 exited caused by one of the running tasks) Reason: Executor Process Lost
+Driver stacktrace:
+	at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2258)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2207)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2206)
+	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
+	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
+	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
+	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2206)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1079)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1079)
+	at scala.Option.foreach(Option.scala:407)
+	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1079)
+	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2445)
+	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2387)
+	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2376)
+	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
+	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:868)
+	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2196)
+	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2291)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$5(Dataset.scala:3629)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$2(Dataset.scala:3633)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$2$adapted(Dataset.scala:3610)
+	at org.apache.spark.sql.Dataset.$anonfun$withAction$1(Dataset.scala:3687)
+	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$5(SQLExecution.scala:103)
+	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:163)
+	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:90)
+	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
+	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:64)
+	at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3685)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$1(Dataset.scala:3610)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$1$adapted(Dataset.scala:3609)
+	at org.apache.spark.security.SocketAuthServer$.$anonfun$serveToStream$2(SocketAuthServer.scala:139)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
+	at org.apache.spark.security.SocketAuthServer$.$anonfun$serveToStream$1(SocketAuthServer.scala:141)
+	at org.apache.spark.security.SocketAuthServer$.$anonfun$serveToStream$1$adapted(SocketAuthServer.scala:136)
+	at org.apache.spark.security.SocketFuncServer.handleConnection(SocketAuthServer.scala:113)
+	at org.apache.spark.security.SocketFuncServer.handleConnection(SocketAuthServer.scala:107)
+	at org.apache.spark.security.SocketAuthServer$$anon$1.$anonfun$run$4(SocketAuthServer.scala:68)
+	at scala.util.Try$.apply(Try.scala:213)
+	at org.apache.spark.security.SocketAuthServer$$anon$1.run(SocketAuthServer.scala:68)
+
+
+Py4JJavaError: An error occurred while calling o255.getResult.
+: org.apache.spark.SparkException: Exception thrown in awaitResult: 
+	at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:301)
+	at org.apache.spark.security.SocketAuthServer.getResult(SocketAuthServer.scala:97)
+	at org.apache.spark.security.SocketAuthServer.getResult(SocketAuthServer.scala:93)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
+	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
+	at py4j.Gateway.invoke(Gateway.java:282)
+	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
+	at py4j.commands.CallCommand.execute(CallCommand.java:79)
+	at py4j.GatewayConnection.run(GatewayConnection.java:238)
+	at java.lang.Thread.run(Thread.java:748)
+Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 99 in stage 7.0 failed 4 times, most recent failure: Lost task 99.3 in stage 7.0 (TID 8779) (worker03 executor 140): ExecutorLostFailure (executor 140 exited caused by one of the running tasks) Reason: Executor Process Lost
+Driver stacktrace:
+	at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2258)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2207)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2206)
+	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
+	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
+	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
+	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2206)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1079)
+	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1079)
+	at scala.Option.foreach(Option.scala:407)
+	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1079)
+	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2445)
+	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2387)
+	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2376)
+	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
+	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:868)
+	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2196)
+	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2291)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$5(Dataset.scala:3629)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$2(Dataset.scala:3633)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$2$adapted(Dataset.scala:3610)
+	at org.apache.spark.sql.Dataset.$anonfun$withAction$1(Dataset.scala:3687)
+	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$5(SQLExecution.scala:103)
+	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:163)
+	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:90)
+	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
+	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:64)
+	at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3685)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$1(Dataset.scala:3610)
+	at org.apache.spark.sql.Dataset.$anonfun$collectAsArrowToPython$1$adapted(Dataset.scala:3609)
+	at org.apache.spark.security.SocketAuthServer$.$anonfun$serveToStream$2(SocketAuthServer.scala:139)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
+	at org.apache.spark.security.SocketAuthServer$.$anonfun$serveToStream$1(SocketAuthServer.scala:141)
+	at org.apache.spark.security.SocketAuthServer$.$anonfun$serveToStream$1$adapted(SocketAuthServer.scala:136)
+	at org.apache.spark.security.SocketFuncServer.handleConnection(SocketAuthServer.scala:113)
+	at org.apache.spark.security.SocketFuncServer.handleConnection(SocketAuthServer.scala:107)
+	at org.apache.spark.security.SocketAuthServer$$anon$1.$anonfun$run$4(SocketAuthServer.scala:68)
+	at scala.util.Try$.apply(Try.scala:213)
+	at org.apache.spark.security.SocketAuthServer$$anon$1.run(SocketAuthServer.scala:68)
+
+(<class 'py4j.protocol.Py4JJavaError'>, Py4JJavaError('An error occurred while calling o255.getResult.\n', JavaObject id=o256), <traceback object at 0x7f89040ab2d0>)
+
+
+# -----------------------------------------------------------------------------------------------------
+# Check Worker02 logs
+# fedora@worker02
+
+tail -f -n 10000 /var/hadoop/logs/hadoop-fedora-nodemanager-iris-gaia-red-20220826-worker02.log
+
+..
+2022-08-29 15:06:22,791 WARN org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor: Exit code from container container_1661525926408_0002_02_000015 is : 143
+..
+
+# -----------------------------------------------------------------------------------------------------
+# Check application logs
+
+grep -r "Exception" /var/hadoop/logs/application_1661525926408_0002
+
+/var/hadoop/logs/application_1661525926408_0002/container_1661525926408_0002_01_000052/stderr:java.lang.IllegalStateException: Memory was leaked by query. Memory leaked: (65536)
+/var/hadoop/logs/application_1661525926408_0002/container_1661525926408_0002_01_000188/stderr:org.apache.spark.rpc.RpcTimeoutException: Futures timed out after [10000 milliseconds]. This timeout is controlled by spark.executor.heartbeatInterval
+/var/hadoop/logs/application_1661525926408_0002/container_1661525926408_0002_01_000188/stderr:	at org.apache.spark.rpc.RpcTimeout.org$apache$spark$rpc$RpcTimeout$$createRpcTimeoutException(RpcTimeout.scala:47)
+/var/hadoop/logs/application_1661525926408_0002/container_1661525926408_0002_01_000188/stderr:	at org.apache.spark.util.Utils$.logUncaughtExceptions(Utils.scala:1996)
+/var/hadoop/logs/application_1661525926408_0002/container_1661525926408_0002_01_000188/stderr:Caused by: java.util.concurrent.TimeoutException: Futures timed out after [10000 milliseconds]
+
+
+..
+
+# -----------------------------------------------------------------------------------------------------
+# Check  /var/hadoop/logs/application_1661525926408_0002/container_1661525926408_0002_01_000052/stderr
+
+2022-08-29 13:41:46,756 WARN python.ArrowPythonRunner: Incomplete task 80.0 in stage 3 (TID 4177) interrupted: Attempting to kill Python Worker
+2022-08-29 13:41:46,756 WARN python.ArrowPythonRunner: Incomplete task 84.0 in stage 3 (TID 4181) interrupted: Attempting to kill Python Worker
+2022-08-29 13:41:46,800 WARN python.ArrowPythonRunner: Incomplete task 81.0 in stage 3 (TID 4178) interrupted: Attempting to kill Python Worker
+2022-08-29 13:41:46,803 ERROR memory.BaseAllocator: Memory was leaked by query. Memory leaked: (65536)
+Allocator(stdin reader for python) 0/65536/133120/9223372036854775807 (res/actual/peak/limit)
+
+2022-08-29 13:41:46,804 ERROR spark.TaskContextImpl: Error in TaskCompletionListener
+java.lang.IllegalStateException: Memory was leaked by query. Memory leaked: (65536)
+Allocator(stdin reader for python) 0/65536/133120/9223372036854775807 (res/actual/peak/limit)
+
+	at org.apache.arrow.memory.BaseAllocator.close(BaseAllocator.java:431)
+	at org.apache.spark.sql.execution.python.PythonArrowOutput$$anon$1.$anonfun$new$1(PythonArrowOutput.scala:63)
+	at org.apache.spark.sql.execution.python.PythonArrowOutput$$anon$1.$anonfun$new$1$adapted(PythonArrowOutput.scala:59)
+	at org.apache.spark.TaskContext$$anon$1.onTaskCompletion(TaskContext.scala:125)
+	at org.apache.spark.TaskContextImpl.$anonfun$markTaskCompleted$1(TaskContextImpl.scala:124)
+	at org.apache.spark.TaskContextImpl.$anonfun$markTaskCompleted$1$adapted(TaskContextImpl.scala:124)
+	at org.apache.spark.TaskContextImpl.$anonfun$invokeListeners$1(TaskContextImpl.scala:137)
+	at org.apache.spark.TaskContextImpl.$anonfun$invokeListeners$1$adapted(TaskContextImpl.scala:135)
+	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
+	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
+	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
+	at org.apache.spark.TaskContextImpl.invokeListeners(TaskContextImpl.scala:135)
+	at org.apache.spark.TaskContextImpl.markTaskCompleted(TaskContextImpl.scala:124)
+	at org.apache.spark.scheduler.Task.run(Task.scala:141)
+	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:497)
+	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
+	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:500)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+
+
+
+# ------------------------------
+# Some interesting/related Links
+
+https://www.slideshare.net/SparkSummit/top-5-mistakes-when-writing-spark-applications-63071421
+https://sparkbyexamples.com/spark/difference-between-spark-sql-shuffle-partitions-and-spark-default-parallelism/
+https://community.cloudera.com/t5/Support-Questions/Diagnostics-Container-killed-on-request-Exit-code-is-143/td-p/240929
+https://stackoverflow.com/questions/41057311/the-value-of-spark-yarn-executor-memoryoverhead-setting
+https://spark.apache.org/docs/latest/sql-performance-tuning.html
+https://stackoverflow.com/questions/32349611/what-should-be-the-optimal-value-for-spark-sql-shuffle-partitions-or-how-do-we-i
+https://zeppelin.apache.org/docs/0.10.0/interpreter/spark.html
+https://stackoverflow.com/questions/42972908/container-killed-by-the-applicationmaster-exit-code-is-143
+
+# Some responses from stackoverflow on the issues:
+
+"""
+Exit code 143 is related to Memory/GC issues. Your default Mapper/reducer memory setting may not be sufficient to run the large data set. Thus, try setting up higher AM, MAP and REDUCER memory when a large yarn job is invoked.
+"""
+
+"""
+From the answer here, spark.sql.shuffle.partitions configures the number of partitions that are used when shuffling data for joins or aggregations.
+
+spark.default.parallelism is the default number of partitions in RDDs returned by transformations like join, reduceByKey, and parallelize when not set explicitly by the user. Note that spark.default.parallelism seems to only be working for raw RDD and is ignored when working with dataframes.
+"""
+
+"""
+spark.default.parallelism is the default number of partition set by spark which is by default 200. and if you want to increase the number of partition than you can apply the property spark.sql.shuffle.partitions to set number of partition in the spark configuration or while running spark SQL.
+"""
+
+"""
+also If number of partitions is near to 2000 then increase it to more than 2000. As spark applies different logic for partition < 2000 and > 2000 which will increase your code performance by decreasing the memory footprint as data default is highly compressed if >2000.
+"""
+
+
+
+# -----------------------------------------
+# Try modifying the spark.sql.shuffle.partitions
+
+spark.sql.shuffle.partitions  2001
+
+# Run same cells
+# Failed, same errors
+
+
+# -----------------------------------------
+# Try modifying the memory per executor
+# fedora@zeppelin
+
+# Set spark.executor.memory                7168m ->	5120m
+
+# Cell completes successfully
+..
+
+%pyspark
+#similar_df.count()
+
+# collect/cash stats to the head for plotting in the next cell - this actually actions the full workflow on the Spark cluster
+stats_pdf = similar_df.select('p_xp_similar').toPandas()
+
+> Took 8 hrs 4 min 33 sec. Last updated by Evison at August 31 2022, 6:10:22 AM.
+
+
+# ------------------------------------------------------------
+# Repeat Test, to check if we can rerun the cell consistently
+
+%pyspark
+#similar_df.count()
+
+# collect/cash stats to the head for plotting in the next cell - this actually actions the full workflow on the Spark cluster
+stats_pdf = similar_df.select('p_xp_similar').toPandas()
+
+> Took 8 hrs 31 min 4 sec. Last updated by Evison at September 06 2022, 4:42:57 AM.
+
+
+# -------------------------
+# Run the next few cells..
+
+# The following cell failed after 37 mins
+
+%pyspark
+
+# convert to a Pandas dataframe for GaiaXPy
+continuous_spectra = similar_df.toPandas()
+
+# convert to sampled form:
+sampled_spectra, sampling = convert(continuous_spectra, save_file = False)
+    
+# plot to sanity check:
+plot_spectra(sampled_spectra, sampling = sampling, multi=True, show_plot=True, output_path=None, legend=True)
+Py4JJavaError: An error occurred while calling o280.getResult.
+: org.apache.spark.SparkException: Exception thrown in awaitResult: 
+	at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:301)
+	at org.apache.spark.security.SocketAuthServer.getResult(SocketAuthServer.scala:97)
+	at org.apache.spark.security.SocketAuthServer.getResult(SocketAuthServer.scala:93)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:498)
+	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
+	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
+	at py4j.Gateway.invoke(Gateway.java:282)
+	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
+	at py4j.commands.CallCommand.execute(CallCommand.java:79)
+	at py4j.GatewayConnection.run(GatewayConnection.java:238)
+	at java.lang.Thread.run(Thread.java:748)
+Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 3 in stage 8.0 failed 4 times, most recent failure: Lost task 3.3 in stage 8.0 (TID 12934) (worker01 executor 212): ExecutorLostFailure (executor 212 exited caused by one of the running tasks) Reason: Container from a bad node: container_1661872020086_0003_02_000047 on host: worker01. Exit status: 143. Diagnostics: [2022-09-06 09:26:08.468]Container killed on request. Exit code is 143
+[2022-09-06 09:26:08.468]Container exited with a non-zero exit code 143. 
+[2022-09-06 09:26:08.469]Killed by external signal
+
+# Two error codes / types of messages in the Spark UI
+
+ExecutorLostFailure (executor 180 exited caused by one of the running tasks) Reason: Container from a bad node: container_1661872020086_0003_02_000008 on host: worker01. Exit status: 143. Diagnostics: [2022-09-06 09:22:07.897]Container killed on request. Exit code is 143
+
+ExecutorLostFailure (executor 133 exited caused by one of the running tasks) Reason: Container from a bad node: container_1661872020086_0003_01_000165 on host: worker03. Exit status: 137. Diagnostics: [2022-09-06 08:49:39.446]Container killed on request. Exit code is 137
+
+
+
+
+

--- a/notes/stv/20220908-experimenting-spark-config-01.txt
+++ b/notes/stv/20220908-experimenting-spark-config-01.txt
@@ -1,0 +1,313 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+# Target:
+  Work on finding the right configuration to run Nigel' spectra notebook without fails
+  Try reducing parallelism  
+
+
+# -----------------------------------------------
+# Run new deploy with same configuration as live
+# zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Create test users.
+#[root@ansibler]
+
+ source /deployments/zeppelin/bin/create-user-tools.sh
+
+ import-test-users
+
+
+
+
+# -----------------------------------------
+# Try modifying the cores per executor
+# fedora@zeppelin
+
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          20480m
+
+spark.executor.memory                7168m
+spark.executor.memoryOverhead         1024
+spark.executor.cores                     4
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+
+
+
+# -------------------------------------------------------------------------------
+# Login and import the example notebook that causes the errors mentioned by Nigel
+
+# Notebook: Work in progress with Gaia XP spectra (Copied from Live deploy)
+
+# Errors: Notebook gets failed tasks, and eventually fails for the full dataset
+# If selecting a subset (10%) the notebook completes, but with failed tasks
+# [root@ansibler]
+
+
+
+
+# -------------------------------------------------------------------------------
+# Manually Edit notebook, modify cell that selects a subset
+# Remove Mod so that we get the full dataset
+
+%pyspark
+
+# select a template for the search, e.g. Proxima Cen
+#sid = 5853498713190525696 # Proxima Cen
+sid = 2585856120791459584 # HIP 7585 (Solar twin)
+template_df = spark.sql('SELECT * FROM xp_continuous_mean_spectrum WHERE source_id = %d'%(sid))
+#spark.sql('SELECT xp.*, g.parallax FROM xp_sampled_mean_spectrum AS xp INNER JOIN gaia_source AS g ON g.source_id = xp.source_id WHERE g.source_id = %d'%(sid))
+
+# grab the template parallax
+#template_parallax = template_df.collect()[0]['parallax']
+
+# define a query over the entire dataset, restricting to low reddening for simplicity
+query = 'SELECT xp.*  ' + \
+        'FROM xp_continuous_mean_spectrum AS xp INNER JOIN gaia_source AS g ON g.source_id = xp.source_id ' + \
+        'WHERE g.ag_gspphot < 0.1'
+        
+# ---------------------------------------------------------------
+# The following cell runs for several hours for the full dataset
+
+
+%pyspark
+#similar_df.count()
+
+# collect/cash stats to the head for plotting in the next cell - this actually actions the full workflow on the Spark cluster
+stats_pdf = similar_df.select('p_xp_similar').toPandas()
+# benchmarks: 1 in 10000 in 45min 21sec; no failed tasks
+#             1 in 1000  in 45min 21sec; ditto
+#             1 in 10    in 46min 57sec; successful completion albeit with 10 failed tasks 
+
+
+
+# ------------------------------------------------------------
+# Run test
+
+# Observe Spark UI & Grafana Monitor / Report 
+
+# After a few mins we see:
+# 32 Failed tasks
+# 116 Active Tasks
+# RAM used: up to 40/42 on a few nodes
+
+
+# Kill job
+
+
+
+
+
+# -----------------------------------------
+# Try modifying the cores per executor to even less
+# fedora@zeppelin
+
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          20480m
+
+spark.executor.memory                7168m
+spark.executor.memoryOverhead         1024
+spark.executor.cores                     2
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+
+
+# ------------------------------------------------------------
+# Run test
+
+# Observe Spark UI & Grafana Monitor / Report 
+
+# After a few mins we see:
+# 42 Failed tasks
+# 54 Active Tasks
+# RAM used: up to 40/42 on a few nodes
+
+# Seems like tasks are failing even more frequently now
+
+# Check worker02 logs (which had some of the failed tasks)
+
+2022-09-07 11:09:49,391 INFO org.apache.hadoop.util.JvmPauseMonitor: Detected pause in JVM or host machine (eg GC): pause of approximately 1542ms
+No GCs detected
+2022-09-07 11:09:49,902 WARN org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor: Exit code from container container_1661872020086_0006_01_000078 is : 137
+2022-09-07 11:09:49,904 INFO org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl: Container container_1661872020086_0006_01_000078 transitioned from RUNNING to EXITED_WITH_FAILURE
+
+
+
+# Kill job
+
+
+
+
+
+
+# --------------------------------------------------------------------
+# Reset the setting, try reducing the dynamicAllocation maxExecutors
+# spark.dynamicAllocation.maxExecutors:   20
+# fedora@zeppelin
+
+
+# Calculated using Cheatsheet.xlsx
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          20480m
+
+spark.executor.memory                7168m
+spark.executor.memoryOverhead         1024
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     20
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+
+
+# ------------------------------------------------------------
+# Run test
+
+# Observe Spark UI & Grafana Monitor / Report 
+
+# After a few mins we see:
+# 15 Failed tasks
+# 101 Active Tasks
+# RAM used: up to 40/42 on one node, around 32-36 on other nodes
+
+# Error logs on worker03:
+
+2022-09-07 11:39:50,410 WARN org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor: Exit code from container container_1661872020086_0009_01_000003 is : 143
+2022-09-07 11:39:50,410 WARN org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor: Exit code from container container_1661872020086_0009_01_000015 is : 143
+2022-09-07 11:39:50,410 WARN org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor: Exit code from container container_1661872020086_0009_01_000030 is : 143
+2022-09-07 11:39:50,410 WARN org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor: Exit code from container container_1661872020086_0009_01_000009 is : 143
+
+# Kill job
+
+
+
+# --------------------------------------------------------------------
+# Reset the setting, try reducing the memory per executor
+# spark.executor.memory :   3072m
+# fedora@zeppelin
+
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          20480m
+
+spark.executor.memory                3072m
+spark.executor.memoryOverhead         1024
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+
+
+# ------------------------------------------------------------
+# Run test
+
+
+# Cell completed after 6.7 hours: 
+#   stats_pdf = similar_df.select('p_xp_similar').toPandas() 
+
+> Took 6 hrs 41 min 48 sec. Last updated by Evison at September 07 2022, 10:18:06 PM.
+
+
+
+# The following cell failed:
+
+# Plot Results
+
+%pyspark
+
+# convert to a Pandas dataframe for GaiaXPy
+continuous_spectra = similar_df.toPandas()
+# convert to sampled form:
+sampled_spectra, sampling = convert(continuous_spectra, save_file = False)
+# plot to sanity check:
+plot_spectra(sampled_spectra, sampling = sampling, multi=True, show_plot=True, output_path=None, legend=True)
+
+
+> Took 15 min 34 sec. Last updated by Evison at September 07 2022, 10:33:42 PM.
+
+
+# 5 Failed tasks
+
+# Various RAM usage patterns for the different workers
+# worker01: Some spikes in usage going up to 39/42 used, then a consistent 20 / 42 for most of the duration
+# worker06: Some spikes in usage going up to 41.80/42 used, then a consistent 38 / 42 for most of the duration. During the initial spikes, we also see a gap with no reporting, soon after the 41.80/42 usage was reached
+# zeppelin: 3/42 consistently, no spikes
+
+
+# Most worker nodes show a spike in RAM around 10:30 PM reaching 41+/42 usage and then a sudden drop down to 5/42
+# This matches with the failure we see above
+ 
+	
+	
+
+
+

--- a/notes/stv/20220912-oom-experiments-01.txt
+++ b/notes/stv/20220912-oom-experiments-01.txt
@@ -1,0 +1,343 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+
+# Target: Run various configurations to try to run the notebook provided by Nigel (Work in progress with Gaia XP spectra) successfully
+#    The following two cells fails for the existing configuration, with the symptoms being failed tasks, which eventually make the cells fail with an error message
+#    The logs of the failed tasks, imply that the containers that are failing are running out of Memory
+
+
+# The Cell in question:
+
+# Cell # 1
+----------
+%pyspark
+#similar_df.count()
+
+# collect/cash stats to the head for plotting in the next cell - this actually actions the full workflow on the Spark cluster
+stats_pdf = similar_df.select('p_xp_similar').toPandas()
+# benchmarks: 1 in 10000 in 45min 21sec; no failed tasks
+#             1 in 1000  in 45min 21sec; ditto
+#             1 in 10    in 46min 57sec; successful completion albeit with 10 failed tasks 
+
+
+
+# Second cell that also fails
+# Cell # 2
+----------
+%pyspark
+
+# convert to a Pandas dataframe for GaiaXPy
+continuous_spectra = similar_df.toPandas()
+
+# convert to sampled form:
+sampled_spectra, sampling = convert(continuous_spectra, save_file = False)
+    
+# plot to sanity check:
+plot_spectra(sampled_spectra, sampling = sampling, multi=True, show_plot=True, output_path=None, legend=True)
+
+
+
+
+# -----------------------------------------------------------------
+# Try reducing total executors and cores per executor
+
+
+
+# Spark Settings
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          20480m
+
+spark.executor.memory                 7168m
+spark.executor.memoryOverhead         1024
+spark.executor.cores                     2
+#spark.executor.instances               30
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors      1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     15
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          1
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout       60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+
+# Failed Tasks
+
+
+# Notes:
+# RAM usage on workers ranged from 4% to 96% during processing
+# So some of the worker nodes were idle
+# 104 Active tasks, 113 Failed tasks after 10 mins
+
+
+# -----------------------------------------------------------------
+# Try reducing RAM per executor
+
+
+# Spark Settings
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 3072m
+spark.executor.memoryOverhead         384m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout	  60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+
+# Failed Tasks
+
+
+# Notes:
+# RAM usage on workers ranged from 3% to 99% during processing
+# One of the worker nodes were idle 
+# 150 Active tasks, 78 Failed tasks after 20 mins
+
+# Logs
+
+2022-09-12 10:55:42,170 ERROR executor.Executor: Exception in task 0.0 in stage 3.0 (TID 4097)
+java.lang.OutOfMemoryError: Java heap space
+	at java.util.Arrays.copyOf(Arrays.java:3236)
+	at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:118)
+	at java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:93)
+	at java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:153)
+	at org.apache.spark.util.ByteBufferOutputStream.write(ByteBufferOutputStream.scala:41)
+	at java.io.ObjectOutputStream$BlockDataOutputStream.write(ObjectOutputStream.java:1853)
+	at java.io.ObjectOutputStream.write(ObjectOutputStream.java:709)
+	at org.apache.spark.util.Utils$.writeByteBuffer(Utils.scala:233)
+	at org.apache.spark.scheduler.DirectTaskResult.$anonfun$writeExternal$1(TaskResult.scala:53)
+	at org.apache.spark.scheduler.DirectTaskResult$$Lambda$1245/906964877.apply$mcV$sp(Unknown Source)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1405)
+	at org.apache.spark.scheduler.DirectTaskResult.writeExternal(TaskResult.scala:51)
+	at java.io.ObjectOutputStream.writeExternalData(ObjectOutputStream.java:1459)
+	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1430)
+	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
+	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
+	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:44)
+	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:101)
+	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:606)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+2022-09-12 10:55:42,553 INFO memory.MemoryStore: MemoryStore cleared
+
+
+
+
+# -----------------------------------------------------------------
+# Add memoryOverhead values for yarn
+# https://spark.apache.org/docs/2.2.0/running-on-yarn.html
+
+# Calculated using Cheatsheet.xlsx
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 7168m
+spark.executor.memoryOverhead         1024m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+spark.yarn.executor.memoryOverhead	1024m
+spark.yarn.driver.memoryOverhead  1024m
+spark.yarn.am.memoryOverhead    1024m
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout	  60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+# Both cells Failed
+# High memory usage on a few of the nodes
+
+
+
+# -----------------------------------------------------------------
+# Reduce Cores & maxExecutors
+
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       2
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 7168m
+spark.executor.memoryOverhead         1024m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.yarn.executor.memoryOverhead     1024m
+#spark.yarn.driver.memoryOverhead  1024m        
+#spark.yarn.am.memoryOverhead   1024m
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     5
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          1
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout	  60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+# 0 Failed tasks
+# 30 Concurrent Active Tasks, 25 Cores, 40  Gb RAM used (After 2-3 hours)
+
+# Cell #1 Success
+> Took 3 hrs 44 min 18 sec. Last updated by Evison at September 12 2022, 6:54:22 PM.
+
+# Cell #2 
+# Tasks failed immediately
+
+2022-09-12 16:01:29,516 ERROR util.SparkUncaughtExceptionHandler: [Container in shutdown] Uncaught exception in thread Thread[Executor task launch worker for task 28.0 in stage 4.0 (TID 6173),5,main]
+java.lang.OutOfMemoryError: Java heap space
+	at java.util.Arrays.copyOf(Arrays.java:3236)
+	at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:118)
+	at java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:93)
+	at java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:153)
+	at org.apache.spark.util.ByteBufferOutputStream.write(ByteBufferOutputStream.scala:41)
+	at java.io.ObjectOutputStream$BlockDataOutputStream.write(ObjectOutputStream.java:1853)
+	at java.io.ObjectOutputStream.write(ObjectOutputStream.java:709)
+	at org.apache.spark.util.Utils$.writeByteBuffer(Utils.scala:233)
+	at org.apache.spark.scheduler.DirectTaskResult.$anonfun$writeExternal$1(TaskResult.scala:53)
+	at org.apache.spark.scheduler.DirectTaskResult$$Lambda$2076/390642980.apply$mcV$sp(Unknown Source)
+	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1405)
+	at org.apache.spark.scheduler.DirectTaskResult.writeExternal(TaskResult.scala:51)
+	at java.io.ObjectOutputStream.writeExternalData(ObjectOutputStream.java:1459)
+	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1430)
+	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
+	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
+	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:44)
+	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:101)
+	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:606)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+
+# Looking at the same logs, is this relevant?
+
+> 2022-09-12 12:10:07,894 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+
+
+# -----------------------------------------------------------------
+# Increase Cores & maxExecutors
+
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 7168m
+spark.executor.memoryOverhead         720m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          2001
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+
+spark.dynamicAllocation.minExecutors      1
+spark.dynamicAllocation.maxExecutors     20
+spark.dynamicAllocation.initialExecutors          1
+
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout       60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+# Cell #1
+# Success with 5 failed tasks
+
+# Cell #2
+# Failed with several failed tasks
+

--- a/notes/stv/20220913-oom-experiments-01.txt
+++ b/notes/stv/20220913-oom-experiments-01.txt
@@ -1,0 +1,631 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+# Continuation of 20220912-oom-experiments-01.txt
+
+# Target: Run various configurations to try to run the notebook provided by Nigel (Work in progress with Gaia XP spectra) successfully
+#    The following two cells fails for the existing configuration, with the symptoms being failed tasks, which eventually make the cells fail with an error message
+#    The logs of the failed tasks, imply that the containers that are failing are running out of Memory
+
+
+# The Cell in question:
+
+# Cell # 1
+----------
+%pyspark
+#similar_df.count()
+
+# collect/cash stats to the head for plotting in the next cell - this actually actions the full workflow on the Spark cluster
+stats_pdf = similar_df.select('p_xp_similar').toPandas()
+# benchmarks: 1 in 10000 in 45min 21sec; no failed tasks
+#             1 in 1000  in 45min 21sec; ditto
+#             1 in 10    in 46min 57sec; successful completion albeit with 10 failed tasks 
+
+
+
+# Second cell that also fails
+# Cell # 2
+----------
+%pyspark
+
+# convert to a Pandas dataframe for GaiaXPy
+continuous_spectra = similar_df.toPandas()
+
+# convert to sampled form:
+sampled_spectra, sampling = convert(continuous_spectra, save_file = False)
+    
+# plot to sanity check:
+plot_spectra(sampled_spectra, sampling = sampling, multi=True, show_plot=True, output_path=None, legend=True)
+
+
+# Run the cell #1 with default settings
+
+# Failed
+20/2048 (160 failed) (130 killed: Stage cancelled)
+
+# Check logs for memory messages
+
+# fedora@worker01
+
+cd /var/hadoop/logs/application_1661872020086_0036
+grep -r "Memory"
+..
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:16:07,048 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:16:08,502 INFO memory.MemoryStore: Block broadcast_9_piece0 stored as bytes in memory (estimated size 91.6 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:16:08,608 INFO memory.MemoryStore: Block broadcast_9 stored as values in memory (estimated size 160.3 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:16:12,007 INFO memory.MemoryStore: Block broadcast_7_piece0 stored as bytes in memory (estimated size 31.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:16:12,109 INFO memory.MemoryStore: Block broadcast_7 stored as values in memory (estimated size 459.7 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:17:30,363 INFO memory.MemoryStore: Block broadcast_8_piece0 stored as bytes in memory (estimated size 30.9 KiB, free 452.3 MiB)
+container_1661872020086_0036_01_000041/stderr:2022-09-13 10:17:30,375 INFO memory.MemoryStore: Block broadcast_8 stored as values in memory (estimated size 459.7 KiB, free 451.8 MiB)
+container_1661872020086_0036_01_000082/launch_container.sh:exec /bin/bash -c "$JAVA_HOME/bin/java -server -Xmx7168m -Djava.io.tmpdir=$PWD/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000082 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 56 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:$PWD/__app__.jar 1>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000082/stdout 2>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000082/stderr"
+container_1661872020086_0036_01_000082/prelaunch.err:/bin/bash: line 1: 180973 Killed                  /etc/alternatives/jre/bin/java -server -Xmx7168m -Djava.io.tmpdir=/var/hadoop/data/usercache/Evison/appcache/application_1661872020086_0036/container_1661872020086_0036_01_000082/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000082 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 56 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:/var/hadoop/data/usercache/Evison/appcache/application_1661872020086_0036/container_1661872020086_0036_01_000082/__app__.jar > /var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000082/stdout 2> /var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000082/stderr
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:22:07,707 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:22:14,721 INFO memory.MemoryStore: Block broadcast_9_piece0 stored as bytes in memory (estimated size 91.6 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:22:15,693 INFO memory.MemoryStore: Block broadcast_9 stored as values in memory (estimated size 160.3 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:22:32,998 INFO memory.MemoryStore: Block broadcast_7_piece0 stored as bytes in memory (estimated size 31.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:22:33,373 INFO memory.MemoryStore: Block broadcast_7 stored as values in memory (estimated size 459.7 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:24:34,600 INFO memory.MemoryStore: Block broadcast_8_piece0 stored as bytes in memory (estimated size 30.9 KiB, free 313.7 MiB)
+container_1661872020086_0036_01_000082/stderr:2022-09-13 10:24:34,663 INFO memory.MemoryStore: Block broadcast_8 stored as values in memory (estimated size 459.7 KiB, free 313.3 MiB)
+container_1661872020086_0036_01_000006/launch_container.sh:exec /bin/bash -c "$JAVA_HOME/bin/java -server -Xmx7168m -Djava.io.tmpdir=$PWD/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000006 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 5 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:$PWD/__app__.jar 1>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000006/stdout 2>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000006/stderr"
+container_1661872020086_0036_01_000006/stderr:2022-09-13 10:14:09,114 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+container_1661872020086_0036_01_000006/stderr:2022-09-13 10:14:29,216 INFO memory.MemoryStore: Block broadcast_1_piece0 stored as bytes in memory (estimated size 11.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000006/stderr:2022-09-13 10:14:29,305 INFO memory.MemoryStore: Block broadcast_1 stored as values in memory (estimated size 32.4 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000006/stderr:2022-09-13 10:14:39,833 INFO memory.MemoryStore: Block broadcast_3_piece0 stored as bytes in memory (estimated size 10.3 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000006/stderr:2022-09-13 10:14:39,839 INFO memory.MemoryStore: Block broadcast_3 stored as values in memory (estimated size 30.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000006/stderr:2022-09-13 10:15:41,722 INFO memory.MemoryStore: MemoryStore cleared
+container_1661872020086_0036_01_000121/launch_container.sh:exec /bin/bash -c "$JAVA_HOME/bin/java -server -Xmx7168m -Djava.io.tmpdir=$PWD/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000121 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 73 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:$PWD/__app__.jar 1>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000121/stdout 2>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000121/stderr"
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:29:18,612 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:29:26,698 INFO memory.MemoryStore: Block broadcast_9_piece0 stored as bytes in memory (estimated size 91.6 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:29:27,505 INFO memory.MemoryStore: Block broadcast_9 stored as values in memory (estimated size 160.3 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:29:47,111 INFO memory.MemoryStore: Block broadcast_7_piece0 stored as bytes in memory (estimated size 31.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:29:47,368 INFO memory.MemoryStore: Block broadcast_7 stored as values in memory (estimated size 459.7 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:31:28,392 INFO memory.MemoryStore: Block broadcast_8_piece0 stored as bytes in memory (estimated size 30.9 KiB, free 464.1 MiB)
+container_1661872020086_0036_01_000121/stderr:2022-09-13 10:31:28,463 INFO memory.MemoryStore: Block broadcast_8 stored as values in memory (estimated size 459.7 KiB, free 463.7 MiB)
+container_1661872020086_0036_01_000038/launch_container.sh:exec /bin/bash -c "$JAVA_HOME/bin/java -server -Xmx7168m -Djava.io.tmpdir=$PWD/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000038 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 23 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:$PWD/__app__.jar 1>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000038/stdout 2>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000038/stderr"
+container_1661872020086_0036_01_000038/prelaunch.err:/bin/bash: line 1: 179914 Killed                  /etc/alternatives/jre/bin/java -server -Xmx7168m -Djava.io.tmpdir=/var/hadoop/data/usercache/Evison/appcache/application_1661872020086_0036/container_1661872020086_0036_01_000038/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000038 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 23 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:/var/hadoop/data/usercache/Evison/appcache/application_1661872020086_0036/container_1661872020086_0036_01_000038/__app__.jar > /var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000038/stdout 2> /var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000038/stderr
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:16:07,088 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:16:08,572 INFO memory.MemoryStore: Block broadcast_9_piece0 stored as bytes in memory (estimated size 91.6 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:16:08,669 INFO memory.MemoryStore: Block broadcast_9 stored as values in memory (estimated size 160.3 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:16:11,985 INFO memory.MemoryStore: Block broadcast_7_piece0 stored as bytes in memory (estimated size 31.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:16:12,104 INFO memory.MemoryStore: Block broadcast_7 stored as values in memory (estimated size 459.7 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:18:27,804 INFO memory.MemoryStore: Block broadcast_8_piece0 stored as bytes in memory (estimated size 30.9 KiB, free 304.1 MiB)
+container_1661872020086_0036_01_000038/stderr:2022-09-13 10:18:27,877 INFO memory.MemoryStore: Block broadcast_8 stored as values in memory (estimated size 459.7 KiB, free 303.7 MiB)
+container_1661872020086_0036_01_000034/launch_container.sh:exec /bin/bash -c "$JAVA_HOME/bin/java -server -Xmx7168m -Djava.io.tmpdir=$PWD/tmp '-Dspark.driver.port=40811' -Dspark.yarn.app.container.log.dir=/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000034 -XX:OnOutOfMemoryError='kill %p' org.apache.spark.executor.YarnCoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@zeppelin:40811 --executor-id 21 --hostname worker01 --cores 5 --app-id application_1661872020086_0036 --resourceProfileId 0 --user-class-path file:$PWD/__app__.jar 1>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000034/stdout 2>/var/hadoop/logs/application_1661872020086_0036/container_1661872020086_0036_01_000034/stderr"
+container_1661872020086_0036_01_000034/stderr:2022-09-13 10:14:36,503 INFO memory.MemoryStore: MemoryStore started with capacity 3.6 GiB
+container_1661872020086_0036_01_000034/stderr:2022-09-13 10:14:40,108 INFO memory.MemoryStore: Block broadcast_3_piece0 stored as bytes in memory (estimated size 10.3 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000034/stderr:2022-09-13 10:14:40,209 INFO memory.MemoryStore: Block broadcast_3 stored as values in memory (estimated size 30.0 KiB, free 3.6 GiB)
+container_1661872020086_0036_01_000034/stderr:2022-09-13 10:15:41,783 INFO memory.MemoryStore: MemoryStore cleared
+
+
+
+# Why is MemoryStore set to 3.6 GiB?
+
+
+# Set Executor memory and memoryOverhead to the limits of a Yarn container (Single Node capability)
+# ---------------------------------------------------------------------------------------------------
+
+# Calculated using Cheatsheet.xlsx
+spark.driver.memory                 58982m
+spark.driver.memoryOverhead          9216m
+spark.driver.cores                       5
+spark.driver.maxResultSize          40960m
+
+spark.executor.memory                36168m
+spark.executor.memoryOverhead        4024m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors      1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout       60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+
+# After 15 mins
+
+# 0 Failed Tasks / 171 tasks Succeeded
+# 25 Active Jobs
+# Ram used # Aprox 50 - 60 % per worker node , 1 worker node has only 5% used
+
+
+# Kill Job, and start cell #2 
+
+# Job Failed after 16mins
+
+ > Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Total size of serialized results of 147 tasks (40.0 GiB) is bigger than spark.driver.maxResultSize (40.0 GiB)
+
+
+
+# Check application/containers for messages referring to "Memory"
+
+..
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:51:37,661 INFO memory.MemoryStore: MemoryStore started with capacity 18.7 GiB
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:51:38,737 INFO memory.MemoryStore: Block broadcast_9_piece0 stored as bytes in memory (estimated size 91.6 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:51:38,819 INFO memory.MemoryStore: Block broadcast_9 stored as values in memory (estimated size 160.3 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:51:41,263 INFO memory.MemoryStore: Block broadcast_7_piece0 stored as bytes in memory (estimated size 31.0 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:51:41,315 INFO memory.MemoryStore: Block broadcast_7 stored as values in memory (estimated size 589.9 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:52:23,988 INFO memory.MemoryStore: Block broadcast_8_piece0 stored as bytes in memory (estimated size 30.9 KiB, free 11.9 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 10:52:23,999 INFO memory.MemoryStore: Block broadcast_8 stored as values in memory (estimated size 589.9 KiB, free 11.9 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:04:06,035 INFO memory.MemoryStore: Block broadcast_12_piece0 stored as bytes in memory (estimated size 101.3 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:04:06,038 INFO memory.MemoryStore: Block broadcast_12 stored as values in memory (estimated size 189.5 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:04:06,176 INFO memory.MemoryStore: Block broadcast_10_piece0 stored as bytes in memory (estimated size 31.6 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:04:06,187 INFO memory.MemoryStore: Block broadcast_10 stored as values in memory (estimated size 589.9 KiB, free 18.7 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:04:47,483 INFO memory.MemoryStore: Block broadcast_11_piece0 stored as bytes in memory (estimated size 30.9 KiB, free 11.9 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:04:47,493 INFO memory.MemoryStore: Block broadcast_11 stored as values in memory (estimated size 589.9 KiB, free 11.9 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:05:33,363 INFO memory.MemoryStore: Block taskresult_4353 stored as bytes in memory (estimated size 273.5 MiB, free 17.1 GiB)
+
+..
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:16:41,790 INFO memory.MemoryStore: Block taskresult_4519 stored as bytes in memory (estimated size 280.9 MiB, free 7.2 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:16:45,573 INFO memory.MemoryStore: Block taskresult_4523 stored as bytes in memory (estimated size 277.6 MiB, free 7.3 GiB)
+container_1661872020086_0041_01_000008/stderr:2022-09-13 11:16:45,575 INFO memory.MemoryStore: Block taskresult_4522 stored as bytes in memory (estimated size 278.3 MiB, free 7.0 GiB)
+container_1661872020086_0041_01_000008/stderr:java.lang.OutOfMemoryError: GC overhead limit exceeded
+container_1661872020086_0041_01_000008/stderr:java.lang.OutOfMemoryError: GC overhead limit exceeded
+container_1661872020086_0041_01_000008/stderr:java.lang.OutOfMemoryError: GC overhead limit exceeded
+
+
+
+# How do we get 18.7?
+
+
+
+
+# Set Executors to 25
+# ---------------------------------------------------------------------------------------------------
+
+# Calculated using Cheatsheet.xlsx
+spark.driver.memory                 58982m
+spark.driver.memoryOverhead          9216m
+spark.driver.cores                       5
+spark.driver.maxResultSize          40960m
+
+spark.executor.memory                7168m
+spark.executor.memoryOverhead        1024m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors      1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout       60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+# Cell 1 Failed tasks..
+# Check UI:
+# 5 containers per node on 5 nodes, 3 containers on the last one, 40 Gb RAM used on the 5 nodes
+
+
+
+# Modify config, so that we get less containers per node, and that we are not too close to the available RAM
+# ----------------------------------------------------------------------------------------------------------
+
+
+spark.driver.memory                 58982m
+spark.driver.memoryOverhead          9216m
+spark.driver.cores                       5
+spark.driver.maxResultSize          40960m
+
+spark.executor.memory                10240m
+spark.executor.memoryOverhead        1024m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors      1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     23
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout       60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+# Run Cell #1
+# After 20 mins, no failed tasks
+# Kill job
+
+
+# Modify config, same number of containers, less RAM per container
+# ----------------------------------------------------------------------------------------------------------
+
+spark.driver.memory                 58982m
+spark.driver.memoryOverhead          9216m
+spark.driver.cores                       5
+spark.driver.maxResultSize          40960m
+
+spark.executor.memory                3072m
+spark.executor.memoryOverhead        360m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors      1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          15
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout       60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+# Run Cell #1
+# After 30 mins, no failed tasks
+
+
+# Modify config, 1 container per node
+# ----------------------------------------------------------------------------------------------------------
+
+spark.driver.memory                 58982m
+spark.driver.memoryOverhead          9216m
+spark.driver.cores                       5
+spark.driver.maxResultSize          40960m
+
+spark.executor.memory                30072m
+spark.executor.memoryOverhead        3600m
+spark.executor.cores                     24
+#spark.executor.instances               30
+
+#spark.default.parallelism              300
+#spark.sql.shuffle.partitions          300
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     6
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          1
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout	  60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+
+
+# Run Cell #1
+# After 2 hours and 30 mins, no failed tasks
+
+
+# One useful link to check out if a given config will run cell #1 is the nodes page of the Yarn UI:
+   http://localhost:8088/cluster/nodes
+   
+# This shows us how many containers (executors) are running per node, and how much memory in total they are using on each node
+
+   
+   
+# Modify config, 20 containers, 5 vcpu per container
+# ----------------------------------------------------------------------------------------------------------
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 7168m
+spark.executor.memoryOverhead         1024m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.yarn.executor.memoryOverhead     1024m
+#spark.yarn.driver.memoryOverhead  1024m        
+#spark.yarn.am.memoryOverhead   1024m
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     20
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          1
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout	  60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+# Run Cell #1
+# Completed After 3 hour 30 mins, no failed tasks
+
+
+# Run Cell #2
+
+# Failed
+Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 34 in stage 4.0 failed 4 times, most recent failure: Lost task 34.3 in stage 4.0 (TID 6310) (worker02 executor 53): ExecutorLostFailure (executor 53 exited caused by one of the running tasks) Reason: Container from a bad node: container_1661872020086_0068_01_000064 on host: worker02. Exit status: 143. Diagnostics: [2022-09-14 19:31:45.971]Container killed on request. Exit code is 143
+
+# Restart Zeppelin and run cell #1 again to confirm that it works without failed tasks
+# Run Cell #1
+# 5 failed tasks after 10 mins..
+	
+
+   
+# 30 containers
+# 6 Gb RAM per executor
+# 5 cores
+# Change Yarn settings to reduce total RAM used per node
+# ----------------------------------------------------------------------------------------------------------
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 6144m
+spark.executor.memoryOverhead         614m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.yarn.executor.memoryOverhead     1024m
+#spark.yarn.driver.memoryOverhead  1024m        
+#spark.yarn.am.memoryOverhead   1024m
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+spark.dynamicAllocation.initialExecutors          1
+spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+spark.dynamicAllocation.executorIdleTimeout	  60s
+spark.sql.execution.arrow.pyspark.enabled            true
+
+..
+
+
+# Yarn:
+   
+cat /opt/hadoop/etc/hadoop/yarn-site.xml  
+
+<property>
+    <name>yarn.scheduler.maximum-allocation-mb</name>
+    <value>40960</value>
+</property>
+
+<!--+
+    | Minimum limit of memory to allocate to each container request at the Resource Manager.
+    +-->
+<property>
+    <name>yarn.scheduler.minimum-allocation-mb</name>
+    <value>1024</value>
+</property>
+
+<property>
+    <name>yarn.scheduler.minimum-allocation-vcores</name>
+    <value>1</value>
+</property>
+
+<property>
+    <name>yarn.scheduler.maximum-allocation-vcores</name>
+    <value>25</value>
+</property>
+
+<property>
+    <name>yarn.nodemanager.resource.memory-mb</name>
+    <value>40960</value>
+</property>
+   
+   
+# Run Cell #1
+# Several Failed jobs
+# RAM usage going up to 41/42 on several nodes
+# Yarn UI shows 5 containers on each of the nodes (6 on the node running the AM master)
+# Mem used 35/40 (Note that we reduced Yarn RAM available to 40Gb)
+
+# Run top on one of the worker nodes
+
+ 289827 fedora    20   0 9681008   7.4g      0 S  24.9  17.5  16:55.49 java                                                                                                                                
+ 290951 fedora    20   0 9417012   7.2g      0 S   0.0  17.1   6:07.11 java                                                                                                                                
+ 289990 fedora    20   0 9477280   7.1g      0 S   2.7  16.9  14:47.12 java                                                                                                                                
+ 291143 fedora    20   0 9435580   7.0g   3832 S   0.0  16.6   5:43.54 java                                                                                                                                
+ 291333 fedora    20   0 9451688   5.9g  12608 S   0.3  14.1   5:36.83 java                                                                                                                                
+ 287492 fedora    20   0   12.8g 423588      0 S   4.3   1.0   4:47.45 java                                                                                                                                
+ 287357 fedora    20   0   12.6g 346264      0 S   0.7   0.8   0:30.96 java                                                                                                                                
+ 291425 fedora    20   0 1087960 248988  43488 R 102.3   0.6  19:34.40 python                                                                                                                              
+ 291429 fedora    20   0 1087960 248924  43424 R 107.0   0.6  19:35.06 python                                                                                                                              
+ 291430 fedora    20   0 1087960 248920  43420 R 101.7   0.6  19:30.78 python                                                                                                                              
+ 291423 fedora    20   0 1087960 248916  43416 R 106.6   0.6  19:28.09 python                                                                                                                              
+ 291435 fedora    20   0 1087960 248916  43416 R 100.3   0.6  19:41.02 python                                                                                                                              
+ 290288 fedora    20   0 1105308 240112  17128 R 125.9   0.5  79:55.30 python                                                                                                                              
+ 290331 fedora    20   0 1104804 239636  17172 R 128.6   0.5  81:25.57 python                                                                                                                              
+ 290340 fedora    20   0 1105308 239244  16268 R 131.9   0.5  80:42.64 python                                                                                                                              
+ 290343 fedora    20   0 1103340 239104  18192 R 123.3   0.5  81:47.55 python                                                                                                                              
+ 290332 fedora    20   0 1104192 238840  16980 R 121.9   0.5  81:49.19 python                                                                                                                              
+ 290297 fedora    20   0 1102008 236956  17268 R 125.6   0.5  80:09.40 python                                                                                                                              
+ 290280 fedora    20   0 1089304 225168  18188 R 135.2   0.5  79:53.67 python                                                                                                                              
+ 290282 fedora    20   0 1089304 223832  16912 R 129.2   0.5  82:56.34 python                                                                                                                              
+ 291235 fedora    20   0 1089164 223256  16440 R 102.3   0.5  25:47.61 python                                                                                                                              
+ 291240 fedora    20   0 1089164 223236  16420 R 101.3   0.5  25:40.60 python                                                                                                                              
+ 291246 fedora    20   0 1089164 223160  16344 R 100.3   0.5  25:55.02 python                                                                                                                              
+ 291049 fedora    20   0 1089164 223072  16260 R  98.7   0.5  30:48.51 python                                                                                                                              
+ 291234 fedora    20   0 1089164 223012  16196 R 101.0   0.5  25:49.41 python                                                                                                                              
+ 291242 fedora    20   0 1089164 222972  16156 R 102.7   0.5  25:54.79 python                                                                                                                              
+ 291037 fedora    20   0 1089164 222452  15500 R  99.3   0.5  31:04.50 python                                                                                                                              
+ 291043 fedora    20   0 1089164 221984  15032 R 101.3   0.5  31:12.98 python                                                                                                                              
+ 291039 fedora    20   0 1089164 221668  14716 R 100.0   0.5  31:03.29 python                                                                                                                              
+ 291046 fedora    20   0 1089164 221616  14664 R 100.3   0.5  31:00.49 python   
+ 290304 fedora    20   0  965792  99444  15716 S   0.0   0.2  81:34.64 python                                                                                                                              
+ 291414 fedora    20   0  280148  36808  11080 S   0.0   0.1   0:01.09 python                                                                                                                              
+ 291225 fedora    20   0  280148  26232    504 S   0.0   0.1   0:01.10 python                                                                                                                              
+ 290241 fedora    20   0  280148  25728      0 S   0.0   0.1   0:02.11 python                                                                                                                              
+ 290263 fedora    20   0  280148  25728      0 S   0.0   0.1   0:02.05 python                                                                                                                              
+ 291028 fedora    20   0  280148  25728      0 S   0.0   0.1   0:02.32 python 
+ ..
+ 
+# java processes taking up 80% python processes taking up 10+%
+ 
+
+
+
+   
+# 30 containers
+# 8 (9) Gb RAM per executor
+# 5 cores
+# Change Yarn settings to reduce total RAM used per node
+# ----------------------------------------------------------------------------------------------------------
+
+# Spark: 
+
+spark.driver.memory                 37888m
+spark.driver.memoryOverhead           5120
+spark.driver.cores                       5
+spark.driver.maxResultSize          30720m
+
+spark.executor.memory                 8192m
+spark.executor.memoryOverhead         819m
+spark.executor.cores                     5
+#spark.executor.instances               30
+
+#spark.yarn.executor.memoryOverhead     1024m
+#spark.yarn.driver.memoryOverhead  1024m        
+#spark.yarn.am.memoryOverhead   1024m
+
+#spark.default.parallelism              100
+#spark.sql.shuffle.partitions          100
+
+# YARN Application Master settings
+spark.yarn.am.memory                 2048m
+spark.yarn.am.cores                      1
+
+spark.dynamicAllocation.enabled          true
+spark.shuffle.service.enabled            true
+spark.dynamicAllocation.minExecutors	  1
+ # spark.executor.instances from Cheatsheet
+spark.dynamicAllocation.maxExecutors     30
+ # maxExecutors / 2
+
+
+# Yarn Settings
+
+<!--+
+    | Maximum limit of memory to allocate to each container request at the Resource Manager.
+    +-->
+<property>
+    <name>yarn.scheduler.maximum-allocation-mb</name>
+    <value>35840</value>
+</property>
+
+<!--+
+    | Minimum limit of memory to allocate to each container request at the Resource Manager.
+    +-->
+<property>
+    <name>yarn.scheduler.minimum-allocation-mb</name>
+    <value>1024</value>
+</property>
+
+<property>
+    <name>yarn.scheduler.minimum-allocation-vcores</name>
+    <value>1</value>
+</property>
+
+<property>
+    <name>yarn.scheduler.maximum-allocation-vcores</name>
+    <value>25</value>
+</property>
+
+<property>
+    <name>yarn.nodemanager.resource.memory-mb</name>
+    <value>35840</value>
+</property>
+
+<!--+
+    | 1:1 -> 1:4 * 26 based on IO wait
+    +-->
+<property>
+    <name>yarn.nodemanager.resource.cpu-vcores</name>
+    <value>25</value>
+</property>
+
+
+
+# Run Cell #1
+# Completed after 2.7 hours, no failed tasks
+
+# Run public Examples
+
+3. Source counts over the sky
+  42 seconds
+
+6. Working with cross-matched surveys
+  1 min 46 seconds
+
+7. Good astrometric solutions via ML Random Forrest classifier
+  8 mins
+

--- a/notes/stv/20220920-run-ingest-01.txt
+++ b/notes/stv/20220920-run-ingest-01.txt
@@ -1,0 +1,234 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+    Target:
+
+        Clean deploy on red with changes to worker memory on 6 worker node config
+        Test Ingest of mcmc_samples_gsp_phot_test
+    Result:
+
+        Work in progress ....
+
+
+# Add 1 Tb for worder nodes hadoop/temp directory, for ingests
+nano zeppelin-26.43-spark-6.26.43.yml
+
+..
+        workers:
+            hosts:
+                worker[01:06]:
+            vars:
+                login:  'fedora'
+                image:  "{{baseimage}}"
+                flavor: "{{workerflavor}}"
+                discs:
+                  - type: 'local'
+                    format: 'ext4'
+                    mntpath: "/mnt/local/vdb"
+                    devname: 'vdb'
+                  - type: 'cinder'
+                    size: 1024
+                    format: 'btrfs'
+                    mntpath: "/mnt/cinder/vdc"
+                    devname: 'vdc'
+                  - type: 'cinder'
+                    size: 1024
+                    format: 'btrfs'
+                    mntpath: "/mnt/cinder/vdd"
+                    devname: 'vdd'
+                  - type: 'cinder'
+                    size: 1024
+                    format: 'btrfs'
+                    mntpath: "/mnt/cinder/vde"
+                    devname: 'vde'
+                paths:
+                    hddatalink: "/var/hadoop/data"
+                    hddatadest: "/mnt/cinder/vdd/hadoop/data"
+                    # Used on workers
+                    # /var/hadoop/temp/nm-local-dir/
+                    hdtemplink: "/var/hadoop/temp"
+                    hdtempdest: "/mnt/cinder/vde/hadoop/temp"
+                    # Used on workers
+                    hdlogslink: "/var/hadoop/logs"
+                    hdlogsdest: "/mnt/local/vdb/hadoop/logs"
+                    # Empty on workers
+                    hdfslogslink: "/var/hdfs/logs"
+                    hdfslogsdest: "/mnt/local/vdb/hdfs/logs"
+                    # Empty on workers
+                    hdfsdatalink: "/var/hdfs/data"
+                    hdfsdatadest: "/mnt/cinder/vdc/hdfs/data"
+
+..
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+
+    source "${HOME:?}/aglais.env"
+
+    agcolour=red
+    agproxymap=3000:3000
+
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+    configname=zeppelin-26.43-spark-6.26.43
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Deploy everything.
+#[root@ansibler]
+
+    time \
+        source /deployments/hadoop-yarn/bin/deploy.sh
+
+    > Done
+  
+
+# -----------------------------------------------------
+# Import our live users.
+#[root@ansibler]
+
+# Modify users config, to only include NHambly and SVoutsinas
+
+    source /deployments/zeppelin/bin/create-user-tools.sh
+    import-live-users
+
+    > Done
+
+
+# Tunnel connection to Zeppelin (& master node)
+
+ssh -L '8080:localhost:8080' fedora@128.232.227.147
+ssh -L '8088:master01:8088' fedora@128.232.227.147
+
+
+# Import DR3 Ingest notebook from Nigel's notebook dir on live service
+
+
+# ------------------------------------------------------------
+# Ingest data to SVoutsinas directory
+
+%pyspark
+
+# uncomment as necessary
+#spark.sql('DROP TABLE mcmc_samples_gsp_phot')
+
+mcmc_samples_gsp_phot_schema = StructType([
+    StructField('solution_id', LongType(), True), # Solution Identifier
+    StructField('source_id', LongType(), False), # Unique source identifier (unique within a particular Data Release)
+    StructField('nsamples', ShortType(), True), # Number of samples in the chain from GSP-Phot
+    StructField('teff', ArrayType(FloatType()), True), # MCMC samples for $T_{\rm eff}$ from GSP-Phot
+    StructField('azero', ArrayType(FloatType()), True), # MCMC samples for extinction $A_0$ from GSP-Phot
+    StructField('logg', ArrayType(FloatType()), True), # MCMC samples for $\log g$ from GSP-Phot
+    StructField('mh', ArrayType(FloatType()), True), # MCMC samples for the metallicity from GSP-Phot
+    StructField('ag', ArrayType(FloatType()), True), # MCMC samples for extinction in G band from GSP-Phot
+    StructField('mg', ArrayType(FloatType()), True), # MCMC samples for $M_{\rm G}$ from GSP-Phot
+    StructField('distancepc', ArrayType(FloatType()), True), # MCMC samples for distance from GSP-Phot
+    StructField('abp', ArrayType(FloatType()), True), # MCMC samples for extinction in $G_{\rm BP}$ band from GSP-Phot
+    StructField('arp', ArrayType(FloatType()), True), # MCMC samples for extinction in $G_{\rm RP}$ band from GSP-Phot
+    StructField('ebpminrp', ArrayType(FloatType()), True), # MCMC samples for reddening $E(G_{\rm BP} - G_{\rm RP})$ from GSP-Phot
+    StructField('log_pos', ArrayType(FloatType()), True), # MCMC samples for the log-posterior from GSP-Phot
+    StructField('log_lik', ArrayType(FloatType()), True), # MCMC samples for the log-likelihood from GSP-Phot
+    StructField('radius', ArrayType(FloatType()), True), # MCMC samples for stellar radius from GSP-Phot
+])
+
+# interim structure for the above with strings for the arrays
+interim_schema = create_interim_schema_for_csv(mcmc_samples_gsp_phot_schema)
+
+# read the csv files against the interim schema
+gdr3_mcmcgsp_schema_df = sqlContext.read.option('mode','failfast').option('comment', '#').option('header','true').option('nullValue','null').schema(interim_schema).csv('file:////user/NHambly/CSV/GDR3/cdn.gea.esac.esa.int/Gaia/gdr3/Astrophysical_parameters/mcmc_samples_gsp_phot/*.csv')
+
+recast_df = cast_all_arrays(gdr3_mcmcgsp_schema_df, mcmc_samples_gsp_phot_schema)
+
+saveToBinnedParquet(recast_df, outputParquetPath = 'file:////user/SVoutsinas/data/GDR3_MCMC_SAMPLES_GSP_PHOT/', buckets = 8192, name = 'mcmc_samples_gsp_phot')
+
+
+> Took 10 hrs 48 min 3 sec. Last updated by SVoutsinas at September 22 2022, 3:34:04 AM.
+
+
+# Check Yarn/Spark UI for failed tasks
+# No failed tasks
+
+# Check Monitor for RAM usage
+#  Usage on worker nodes ranging from 20/43 to 25/43
+
+
+# ----------------------------
+# Test ingested data
+
+%pyspark
+
+reattachParquetFileResourceToSparkContext(table_name = 'mcmc_samples_gsp_phot_test', file_path = 'file:////user/SVoutsinas/data/GDR3_MCMC_SAMPLES_GSP_PHOT/', schema_structures = (mcmc_samples_gsp_phot_schema,))
+# ... replaces csv-backed table resource with the parquet one in the system catalogue 
+
+# DF backed by the parquet file set
+pdf = spark.sql('select count(*) from mcmc_samples_gsp_phot_test')
+pdf.show()
+
++---------+
+| count(1)|
++---------+
+|449297716|
++---------+
+
+
+# ----------------------------
+# Run all Public Examples
+
+# 1. Start Here [Success]
+
+# 2. Data holdings [Success]
+
+# 3. Source counts over the sky [Success]  
+#     Duration: 1min 59 seconds
+
+# 4. Mean proper motions over the sky
+#     Duration: 7 min 4 sec.
+
+# 5. Working with Gaia XP spectra
+#     Duration: 5 hours 9 minutes
+
+# 6. Working with cross-matched surveys
+#     Duration: 3 min 29 seconds
+
+# 7. Good astrometric solutions via ML Random Forest classifier
+#     Duration: 13 mins
+
+
+# Note, we are using Ceph for tmp storage, so it make sense that these are slower than usual

--- a/notes/stv/20221010-ingests-01.txt
+++ b/notes/stv/20221010-ingests-01.txt
@@ -1,0 +1,24 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+# Handed over deploy with this configuration (on red) for Nigel to try out the Ingests.
+# Nigel noted that all ingests completed without Failed Spark jobs
+# New ingested Parquet data available under Nigel's /user directory. TODO: move to public data directory

--- a/notes/stv/20221013-validation-tests-01.txt
+++ b/notes/stv/20221013-validation-tests-01.txt
@@ -1,0 +1,108 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+
+    Target:
+
+        Test Spectra notebook & public examples before doing a PR (2022/10/13)
+
+    Result:
+
+        Success
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    agcolour=red
+    agproxymap=3000:3000
+
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+    configname=zeppelin-26.43-spark-6.26.43
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Deploy everything.
+#[root@ansibler]
+
+    time \
+        source /deployments/hadoop-yarn/bin/deploy.sh
+
+        > Done
+        
+# -----------------------------------------------------
+# Import our live users.
+#[root@ansibler]
+
+    source /deployments/zeppelin/bin/create-user-tools.sh
+
+    import-test-users
+
+# -----------------------------------------------------
+# Start NGINX so that we can access using public IP.
+#[fedorat@zeppelin]
+
+    sudo service nginx start
+
+
+# User1:  Reyesfan
+
+# -----------------------------------------------------
+# Upload and run Work in progress with Gaia XP spectra
+# (Notebook provided by Nigel, was getting OOM exceptions with existing deploy)
+
+
+# Completed after 30 mins / No failed tasks 
+# [Success]
+
+
+# Run all public Notebooks
+1. Start Here   -  < 35s
+2. Data Holdings   -  < 30s
+3. Source counts over the sky    -   ~ 30s
+4. Mean proper motions over the sky   -   ~ 50s
+5. Working with Gaia XP spectra   -   30min
+6. Working with cross-matched surveys   -   1min 54s
+7. Good astrometric solutions via ML Random Forest classifier  -  8min
+
+# [Success]
+


### PR DESCRIPTION
PR includes:

- Notes on debugging failed Spark jobs (OOM)
- Changes to Spark & Hadoop config, to fix OOM errors. Reduce memory Yarn knows about, and set mem per executor so that we leave enough space for other processes (Python PySpark jobs for example) so that we don't overwhelm the node
- Notes on testing new config 

Changes have only been applied to the **zeppelin-26.43-spark-6.26.43** config