### PR TITLE
Certificate renewal fix

### DIFF
--- a/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
+++ b/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
@@ -47,6 +47,12 @@
         update_cache: yes
         state: present
 
+    - name: "Start Crond"
+      service:
+        name: crond
+        state: restarted
+      become: yes
+
     - name: "Generate NGINX configuration"
       become: true
       template:

--- a/notes/stv/20221028-certificates-01.txt
+++ b/notes/stv/20221028-certificates-01.txt
@@ -1,0 +1,153 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Renew certificate for live service, debug what went wrong
+
+    Result:
+  
+        Success
+  
+  
+        
+# The SSL certificate for the live system has expired.
+
+# Need to figure out why the automated renewal didn't work.
+  
+  
+# Navigate to https://dmp.gaia.ac.uk  
+# Error message, confirms that the certificate is expired
+
+
+
+# --------------------------------------
+# Dry run the renewal of the certificate
+# [fedora@dmp.gaia.ac.uk]
+
+certbot renew --cert-name dmp.gaia.ac.uk --dry-run
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/dmp.gaia.ac.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Cert is due for renewal, auto-renewing...
+Plugins selected: Authenticator nginx, Installer nginx
+Renewing an existing certificate
+Performing the following challenges:
+http-01 challenge for dmp.gaia.ac.uk
+Waiting for verification...
+Cleaning up challenges
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+new certificate deployed with reload of nginx server; fullchain is
+/etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+** DRY RUN: simulating 'certbot renew' close to cert expiry
+**          (The test certificates below have not been saved.)
+
+Congratulations, all renewals succeeded. The following certs have been renewed:
+  /etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem (success)
+** DRY RUN: simulating 'certbot renew' close to cert expiry
+**          (The test certificates above have not been saved.)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+IMPORTANT NOTES:
+ - Your account credentials have been saved in your Certbot
+   configuration directory at /etc/letsencrypt. You should make a
+   secure backup of this folder now. This configuration directory will
+   also contain certificates and private keys obtained by Certbot so
+   making regular backups of this folder is ideal.
+
+
+# --------------------------------------
+# Renew certificate
+# [fedora@dmp.gaia.ac.uk]
+
+ certbot renew --cert-name dmp.gaia.ac.uk --dry-run
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/dmp.gaia.ac.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Cert is due for renewal, auto-renewing...
+Plugins selected: Authenticator nginx, Installer nginx
+Renewing an existing certificate
+Performing the following challenges:
+http-01 challenge for dmp.gaia.ac.uk
+Waiting for verification...
+Cleaning up challenges
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+new certificate deployed with reload of nginx server; fullchain is
+/etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+** DRY RUN: simulating 'certbot renew' close to cert expiry
+**          (The test certificates below have not been saved.)
+
+Congratulations, all renewals succeeded. The following certs have been renewed:
+  /etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem (success)
+** DRY RUN: simulating 'certbot renew' close to cert expiry
+**          (The test certificates above have not been saved.)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+IMPORTANT NOTES:
+ - Your account credentials have been saved in your Certbot
+   configuration directory at /etc/letsencrypt. You should make a
+   secure backup of this folder now. This configuration directory will
+   also contain certificates and private keys obtained by Certbot so
+   making regular backups of this folder is ideal.
+[root@iris-gaia-blue-20221013-zeppelin fedora]# certbot renew --cert-name dmp.gaia.ac.uk 
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/dmp.gaia.ac.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Cert is due for renewal, auto-renewing...
+Plugins selected: Authenticator nginx, Installer nginx
+Renewing an existing certificate
+Performing the following challenges:
+http-01 challenge for dmp.gaia.ac.uk
+Waiting for verification...
+Cleaning up challenges
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+new certificate deployed with reload of nginx server; fullchain is
+/etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+Congratulations, all renewals succeeded. The following certs have been renewed:
+  /etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem (success)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+# Navigate to https://dmp.gaia.ac.uk [Success]
+
+
+

--- a/notes/stv/20221028-debugging-crond-01.txt
+++ b/notes/stv/20221028-debugging-crond-01.txt
@@ -1,0 +1,180 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Debug what went wrong with automated certificate renewal
+
+    Result:
+  
+        Success
+
+# -----------------------------------------------------
+# Check which cloud is currently live.
+#[user@desktop]
+
+    ssh fedora@live.gaia-dmp.uk \
+        '
+        date
+        hostname
+        '
+
+    >   iris-gaia-blue-20221013-zeppelin
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    # Use Red for deploy
+    
+    source "${HOME:?}/aglais.env"
+
+    agcolour=red
+    configname=zeppelin-26.43-spark-3.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+    >  Done
+
+
+
+# -----------------------------------------------------
+# Create everything.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "dmp.gaia.ac.uk" \
+        | tee /tmp/create-all.log
+
+    >  Done
+
+    
+# -----------------------------------------------------
+# Add the ssh key for our data node.
+# This is used by the getpasshash function in the client container.
+#[root@ansibler]
+
+    ssh-keyscan 'data.aglais.uk' >> "${HOME}/.ssh/known_hosts"
+    
+
+
+# -----------------------------------------------------
+# Copy certificates from data server
+#[root@ansibler]
+
+    scp -r fedora@data.aglais.uk:/home/fedora/certs/ /root/
+    
+    
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/setup-ssl.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/setup-ssl.log
+
+        > Done
+ 
+# -----------------------------------------------------
+# Check status of cronjob for cerbot renewal
+# fedora@zeppelin
+
+crontab -l
+#Ansible: Renew Certificate with certbot at 4:10 everyday
+10 4 * * * sudo certbot renew --quiet
+
+
+# Crontab gets created, but not run?
+
+# Is cron running?
+    
+sudo systemctl status crond
+● crond.service - Command Scheduler
+   Loaded: loaded (/usr/lib/systemd/system/crond.service; enabled; vendor preset: enabled)
+   Active: inactive (dead)
+
+
+# We are installing crond, but not starting it
+# Start manually
+sudo systemctl restart crond
+
+ 
+# (Checked status of crond on dmp.gaia.ac.uk, it is also not running there, so that seems to be the issue) 
+ 
+# Check status
+sudo systemctl status crond
+
+● crond.service - Command Scheduler
+   Loaded: loaded (/usr/lib/systemd/system/crond.service; enabled; vendor preset: enabled)
+   Active: active (running) since Mon 2022-10-31 20:04:39 UTC; 27s ago
+ Main PID: 61259 (crond)
+    Tasks: 2 (limit: 51743)
+   Memory: 5.7M
+      CPU: 162ms
+   CGroup: /system.slice/crond.service
+           ├─60801 /usr/sbin/anacron -s
+           └─61259 /usr/sbin/crond -n
+
+
+
+# Create a cronjob to create a file
+crontab -l
+#Ansible: Renew Certificate with certbot at 4:10 everyday
+* * * * * sudo touch /tmp/test
+
+
+# File created successfully, so cronjob seems to be working now
+

--- a/notes/stv/20221101-certificates-fix-test-01.txt
+++ b/notes/stv/20221101-certificates-fix-test-01.txt
@@ -1,0 +1,169 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Deploy with HTTPS and test that cron renew job is active
+
+    Result:
+  
+        Success
+
+# -----------------------------------------------------
+# Check which cloud is currently live.
+#[user@desktop]
+
+    ssh fedora@live.gaia-dmp.uk \
+        '
+        date
+        hostname
+        '
+
+    >   iris-gaia-blue-20221013-zeppelin
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    # Use Red for deploy
+    
+    source "${HOME:?}/aglais.env"
+
+    agcolour=red
+    configname=zeppelin-26.43-spark-3.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+    >  Done
+
+
+
+# -----------------------------------------------------
+# Create everything.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "dmp.gaia.ac.uk" \
+        | tee /tmp/create-all.log
+
+    >  Done
+	    
+    > real	48m31.672s
+    > user	5m15.714s
+    > sys	1m3.531s
+
+    
+# -----------------------------------------------------
+# Add the ssh key for our data node.
+# This is used by the getpasshash function in the client container.
+#[root@ansibler]
+
+    ssh-keyscan 'data.aglais.uk' >> "${HOME}/.ssh/known_hosts"
+    
+
+
+# -----------------------------------------------------
+# Copy certificates from data server
+#[root@ansibler]
+
+    scp -r fedora@data.aglais.uk:/home/fedora/certs/ /root/
+    
+    
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/setup-ssl.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/setup-ssl.log
+
+        > Done
+        
+        
+# -----------------------------------------------------
+# Check status of cronjob for cerbot renewal
+# fedora@zeppelin
+
+crontab -l
+#Ansible: Renew Certificate with certbot at 4:10 everyday
+10 4 * * * sudo certbot renew --quiet
+
+
+
+sudo service crond status
+Redirecting to /bin/systemctl status crond.service
+● crond.service - Command Scheduler
+   Loaded: loaded (/usr/lib/systemd/system/crond.service; enabled; vendor preset: enabled)
+   Active: active (running) since Tue 2022-11-01 14:50:34 UTC; 1min 26s ago
+ Main PID: 67254 (crond)
+    Tasks: 1 (limit: 51743)
+   Memory: 1.1M
+      CPU: 131ms
+   CGroup: /system.slice/crond.service
+           └─67254 /usr/sbin/crond -n
+
+Nov 01 14:50:34 iris-gaia-red-20221101-zeppelin systemd[1]: Started Command Scheduler.
+Nov 01 14:50:34 iris-gaia-red-20221101-zeppelin crond[67254]: (CRON) STARTUP (1.5.4)
+Nov 01 14:50:34 iris-gaia-red-20221101-zeppelin crond[67254]: (CRON) INFO (Syslog will be used instead of sendmail.)
+Nov 01 14:50:34 iris-gaia-red-20221101-zeppelin crond[67254]: (CRON) INFO (RANDOM_DELAY will be scaled with factor 41% if used.)
+Nov 01 14:50:34 iris-gaia-red-20221101-zeppelin crond[67254]: (CRON) INFO (running with inotify support)
+
+
+
+
+
+
+


### PR DESCRIPTION
We install crond, but never actually start it. This caused the certificate to not be renewed automatically for dmp.gaia.ac.uk
Change ansible scripts to now correctly start the service.

Fixes issue: https://github.com/wfau/gaia-dmp/issues/1030