### PR TITLE
Add confirmation before deleting live service

### DIFF
--- a/deployments/hadoop-yarn/bin/deploy.sh
+++ b/deployments/hadoop-yarn/bin/deploy.sh
@@ -26,7 +26,7 @@
 live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
 
 if [[ "$live_hostname" == *"$cloudname"* ]]; then
-    read -p "You are deleting the current live system!! Do you want to proceed? (y/n) " -n 1 -r
+    read -p "You are replacing the current live system!! Do you want to proceed? (y/N) " -n 1 -r
     echo
     if [[ $REPLY != "y" ]];
     then

--- a/deployments/hadoop-yarn/bin/deploy.sh
+++ b/deployments/hadoop-yarn/bin/deploy.sh
@@ -22,17 +22,16 @@
 # ----------------------------------------------------------------
 # Check if we are deleting live, confirm before continuing if yes
 
+    live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
 
-live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
-
-if [[ "$live_hostname" == *"$cloudname"* ]]; then
-    read -p "You are replacing the current live system!! Do you want to proceed? (y/N) " -n 1 -r
-    echo
-    if [[ $REPLY != "y" ]];
-    then
-        exit
+    if [[ "$live_hostname" == *"$cloudname"* ]]; then
+        read -p "You are replacing the current live system!! Do you want to proceed? (y/N) " -n 1 -r
+        echo
+        if [[ $REPLY != "y" ]];
+        then
+            exit
+        fi
     fi
-fi
 
 # -----------------------------------------------------
 # Delete everything.

--- a/deployments/hadoop-yarn/bin/deploy.sh
+++ b/deployments/hadoop-yarn/bin/deploy.sh
@@ -19,6 +19,21 @@
 # </meta:header>
 #
 
+# ----------------------------------------------------------------
+# Check if we are deleting live, confirm before continuing if yes
+
+
+live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
+
+if [[ "$live_hostname" == *"$cloudname"* ]]; then
+    read -p "You are deleting the current live system!! Do you want to proceed? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY != "y" ]];
+    then
+        exit
+    fi
+fi
+
 # -----------------------------------------------------
 # Delete everything.
 #[root@ansibler]

--- a/deployments/openstack/bin/delete-all.sh
+++ b/deployments/openstack/bin/delete-all.sh
@@ -47,6 +47,23 @@
     source /deployments/openstack/bin/settings.sh
 
 
+# ----------------------------------------------------------------
+# Check if we are deleting live, confirm before continuing if yes
+
+
+    live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
+    live_hostname="iris-gaia-green-232032"
+
+    if [[ "$live_hostname" == *"$cloudname"* ]]; then
+        read -p "You are deleting the current live system!! Do you want to proceed? (y/N) " -n 1 -r
+        echo
+        if [[ $REPLY != "y" ]];
+        then
+            exit
+        fi
+    fi
+
+
 # -----------------------------------------------------
 # Sanity check.
 

--- a/notes/stv/20230127-testing-confirm-message.txt
+++ b/notes/stv/20230127-testing-confirm-message.txt
@@ -1,0 +1,163 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+    Target:
+
+        Check confirmation before deploying on live works
+
+
+    Result:
+
+        Success.
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    agcolour=green
+    configname=zeppelin-54.86-spark-6.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+
+# -----------------------------------------------------
+# First to check that it correctly stops if we try to deploy on live, change the script to set the live-hostname to green to fake a live service on green
+# user@desktop
+
+nano deployments/hadoop-yarn/bin/deploy.sh
+..
+
+#live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
+live_hostname="iris-gaia-green-20220923"
+
+if [[ "$live_hostname" == *"$cloudname"* ]]; then
+    read -p "You are deleting the current live system!! Do you want to proceed? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY != "y" ]];
+    then
+        exit
+    fi
+fi
+..
+
+
+
+# -----------------------------------------------------
+# Check that the script works 
+# root@ansibler
+   
+
+# Try stopping
+
+time \
+ source /deployments/hadoop-yarn/bin/deploy.sh 
+		
+	> You are deleting the current live system!! Do you want to proceed? (y/n) n
+
+		> real	0m1.280s
+		> user	0m0.000s
+		> sys	0m0.000s
+		
+	# Script correctly stops
+		
+	
+# Try continuing
+
+time \
+ source /deployments/hadoop-yarn/bin/deploy.sh 
+	
+		                
+       > You are deleting the current live system!! Do you want to proceed? (y/n) y
+
+	---- ---- ----
+	File [delete-all.sh]
+	Path [/deployments/openstack/bin]
+	Tree [/deployments]
+	---- ---- ----
+	Cloud name [iris-gaia-green]
+	---- ---- ----
+
+	# Script correctly continues
+
+
+# ---------------------------------------------------------------------------
+# Undo change to create fake live service, check deploy works without message
+# user@desktop
+
+nano deployments/hadoop-yarn/bin/deploy.sh
+..
+
+live_hostname=$(ssh  -o "StrictHostKeyChecking no" fedora@live.gaia-dmp.uk 'hostname')
+
+if [[ "$live_hostname" == *"$cloudname"* ]]; then
+    read -p "You are deleting the current live system!! Do you want to proceed? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY != "y" ]];
+    then
+        exit
+    fi
+fi
+..
+
+# ---------------------------------------------------------------------------
+# Check that deploy works without confirmation
+# root@ansibler
+
+time \
+ source /deployments/hadoop-yarn/bin/deploy.sh 
+	
+	> 
+	        
+	Warning: Permanently added 'live.gaia-dmp.uk' (ED25519) to the list of known hosts.
+
+	---- ---- ----
+	File [delete-all.sh]
+	Path [/deployments/openstack/bin]
+	Tree [/deployments]
+	---- ---- ----
+	Cloud name [iris-gaia-green]
+	---- ---- ----
+
+
+	
+	


### PR DESCRIPTION
Adds a check to the deploy script to assert whether the new deploy flavour matches what is currently live.
If so, only continue after confirmation.

Addresses issue #1104 