### PR TITLE
Fix zeptarurl var name in zeppelin config

### DIFF
--- a/deployments/hadoop-yarn/ansible/config/zeppelin.yml
+++ b/deployments/hadoop-yarn/ansible/config/zeppelin.yml
@@ -23,7 +23,7 @@
 # Zeppelin vars
 zepvers: "0.10.1-gaia-dmp-0.1"
 zepname: "zeppelin-{{zepvers}}"
-zepurl: "https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_e216e6b502134b6185380be6ccd0bf09/archive/{{zepname}}.tar.gz"
+zeptarurl: "https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_e216e6b502134b6185380be6ccd0bf09/archive/{{zepname}}.tar.gz"
 zepbase: "/home/fedora"
 zephome: "/home/fedora/zeppelin"
 zephost: "zeppelin"


### PR DESCRIPTION
Change zepurl to zeptarurl in zeppelin config to match what is in the 27-install-zeppelin.yml playbook