### PR TITLE
Enable wildcard certificate / Single certificate for all gaia-dmp.uk domains

### DIFF
--- a/deployments/hadoop-yarn/ansible/29-install-pip-libs.yml
+++ b/deployments/hadoop-yarn/ansible/29-install-pip-libs.yml
@@ -64,6 +64,10 @@
         name: libtiff-devel,libjpeg-devel,libzip-devel,freetype-devel,lcms2-devel,libwebp-devel,tcl-devel,tk-devel,libffi,libffi-devel
         state: present
 
+    - name: "Upgrade pip"
+      become: true
+      command: "pip install --upgrade pip"
+
     - name: Copy pip requirements file into tmp
       become: true
       copy:

--- a/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
+++ b/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
@@ -25,6 +25,7 @@
   gather_facts: false
   vars_files:
     - config/ansible.yml
+    - config/domains.yml
     - /opt/aglais/aglais-status.yml
   vars:
     nginx_config_dir: "/etc/nginx/conf.d/"
@@ -58,8 +59,6 @@
       template:
         src:  "templates/nginx-ssl.j2"
         dest: "{{ nginx_config_dir }}/zeppelin.conf"
-      vars:
-        hostname: "{{aglais.status.deployment.hostname}}"
 
     - name: "Copy Certificates to Zeppelin"
       become: true

--- a/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
+++ b/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
@@ -30,14 +30,14 @@
   vars:
     nginx_config_dir: "/etc/nginx/conf.d/"
   tasks:
-    - name: "Install certbot using Yum"   
+
+    - name: "Install certbot_dns_duckdns"
       become: true
-      yum:
-        name: 
-          - certbot
-          - python3-certbot-nginx
-        update_cache: yes
-        state: present
+      command: "pip3 install certbot_dns_duckdns"
+
+    - name: "Install certbot-nginx"
+      become: true
+      command: "pip3 install certbot-nginx"
 
     - name: "Install Cron"
       become: true

--- a/deployments/hadoop-yarn/ansible/config/domains.yml
+++ b/deployments/hadoop-yarn/ansible/config/domains.yml
@@ -1,0 +1,27 @@
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+# Host vars
+blue_hostname: "iris-gaia-blue.gaia-dmp.uk"
+green_hostname: "iris-gaia-green.gaia-dmp.uk"
+red_hostname: "iris-gaia-red.gaia-dmp.uk"
+dev_root_hostname: "gaia-dmp.uk"
+prod_hostname: "dmp.gaia.ac.uk"

--- a/deployments/hadoop-yarn/ansible/templates/nginx-ssl.j2
+++ b/deployments/hadoop-yarn/ansible/templates/nginx-ssl.j2
@@ -7,10 +7,175 @@ upstream zeppelin {
 server {
     listen 80;
     listen 443 ssl;
-    server_name {{ hostname }};
+    server_name {{ blue_hostname }};
 
-    ssl_certificate /etc/letsencrypt/live/{{ hostname }}/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/{{ hostname }}/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/{{ dev_root_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ dev_root_hostname }}/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    if ($ssl_protocol = "") {
+        rewrite ^ https://$host$request_uri? permanent;  # optional, to force use of HTTPS
+    }
+
+    location / {    # For regular websever support
+        proxy_pass http://zeppelin;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_redirect off;
+
+        client_max_body_size       10m;
+        client_body_buffer_size    128k;
+
+        proxy_connect_timeout      90;
+        proxy_send_timeout         90;
+        proxy_read_timeout 86400;
+
+        proxy_buffer_size          4k;
+        proxy_buffers              4 32k;
+        proxy_busy_buffers_size    64k;
+        proxy_temp_file_write_size 64k;
+
+    }
+
+    location /ws {  # For websocket support
+        proxy_pass http://zeppelin/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade websocket;
+        proxy_set_header Connection upgrade;
+        proxy_read_timeout 86400;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+
+    }
+}
+
+# Zeppelin Website
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name {{ green_hostname }};
+
+    ssl_certificate /etc/letsencrypt/live/{{ dev_root_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ dev_root_hostname }}/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    if ($ssl_protocol = "") {
+        rewrite ^ https://$host$request_uri? permanent;  # optional, to force use of HTTPS
+    }
+
+    location / {    # For regular websever support
+        proxy_pass http://zeppelin;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_redirect off;
+
+        client_max_body_size       10m;
+        client_body_buffer_size    128k;
+
+        proxy_connect_timeout      90;
+        proxy_send_timeout         90;
+        proxy_read_timeout 86400;
+
+        proxy_buffer_size          4k;
+        proxy_buffers              4 32k;
+        proxy_busy_buffers_size    64k;
+        proxy_temp_file_write_size 64k;
+
+    }
+
+    location /ws {  # For websocket support
+        proxy_pass http://zeppelin/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade websocket;
+        proxy_set_header Connection upgrade;
+        proxy_read_timeout 86400;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+
+    }
+}
+
+# Zeppelin Website
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name {{ red_hostname }};
+
+    ssl_certificate /etc/letsencrypt/live/{{ dev_root_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ dev_root_hostname }}/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    if ($ssl_protocol = "") {
+        rewrite ^ https://$host$request_uri? permanent;  # optional, to force use of HTTPS
+    }
+
+    location / {    # For regular websever support
+        proxy_pass http://zeppelin;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_redirect off;
+
+        client_max_body_size       10m;
+        client_body_buffer_size    128k;
+
+        proxy_connect_timeout      90;
+        proxy_send_timeout         90;
+        proxy_read_timeout 86400;
+
+        proxy_buffer_size          4k;
+        proxy_buffers              4 32k;
+        proxy_busy_buffers_size    64k;
+        proxy_temp_file_write_size 64k;
+
+    }
+
+    location /ws {  # For websocket support
+        proxy_pass http://zeppelin/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade websocket;
+        proxy_set_header Connection upgrade;
+        proxy_read_timeout 86400;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+
+    }
+}
+
+# Zeppelin Website
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name {{ prod_hostname }};
+
+    ssl_certificate /etc/letsencrypt/live/{{ prod_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ prod_hostname }}/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 

--- a/notes/stv/20230314-test-deploy-wildcard-01.txt
+++ b/notes/stv/20230314-test-deploy-wildcard-01.txt
@@ -1,0 +1,408 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+    Target:
+
+        Test deployment on blue
+       
+
+    Result:
+
+        Success.
+        New test deployment passes tests.
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+  
+    source "${HOME:?}/aglais.env"
+
+    agcolour=blue
+    configname=zeppelin-54.86-spark-6.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+        
+
+# -----------------------------------------------------
+# Deploy everything.
+#[root@ansibler]
+
+    time \
+        source /deployments/hadoop-yarn/bin/deploy.sh
+        
+	> 
+		
+	aglais:
+	  status:
+	    deployment:
+	      type: hadoop-yarn
+	      conf: zeppelin-54.86-spark-6.26.43
+	      name: iris-gaia-blue-20230314
+	      date: 20230314T143825
+	      hostname: zeppelin.gaia-dmp.uk
+	  spec:
+	    openstack:
+	      cloud:
+		base: arcus
+		name: iris-gaia-blue
+
+	real	65m56.552s
+	user	7m57.821s
+	sys	2m10.439s
+
+
+			
+# -----------------------------------------------------
+# Copy certificates from data server.
+#[root@ansibler]        
+  scp -r fedora@data.gaia-dmp.uk:/home/fedora/certs/20230314/ /root/certs/
+   > certs.tar.gz                                                 100%   22KB 112.1KB/s   00:00    
+
+
+
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+	
+    /deployments/hadoop-yarn/bin/setup-ssl.sh \
+        "${cloudname:?}" \
+        "${configname:?}" \
+    | tee /tmp/setup-ssl.log
+
+
+	> 
+	
+	PLAY RECAP *********************************************************************
+	zeppelin                   : ok=7    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+
+
+# -----------------------------------------------------
+# Test the HTTPS endpoint using firefox.
+#[user@desktop]
+
+
+    firefox \
+        --new-window \
+        'https://iris-gaia-blue.gaia-dmp.uk/'
+
+        # Success
+        
+# -----------------------------------------------------
+# Test the HTTP endpoint using firefox.
+#[user@desktop]
+ 
+ 
+     firefox \
+        --new-window \
+        'https://iris-gaia-blue.gaia-dmp.uk/'
+
+        # Success / Redirected to HTTPS page
+        
+
+# -----------------------------------------------------
+# Get the public IP address of our Zeppelin node.
+#[root@ansibler]
+
+
+    deployname=$(
+        yq eval \
+            '.aglais.status.deployment.name' \
+            '/opt/aglais/aglais-status.yml'
+        )
+
+    zeppelinid=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server list \
+                --format json \
+        | jq -r '.[] | select(.Name == "'${deployname:?}'-zeppelin") | .ID'
+        )
+
+    zeppelinip=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server show \
+                --format json \
+                "${zeppelinid:?}" \
+        | jq -r ".addresses | .\"${deployname}-internal-network\" | .[1]"
+        )
+
+cat << EOF
+Zeppelin ID [${zeppelinid:?}]
+Zeppelin IP [${zeppelinip:?}]
+EOF
+
+
+
+# ------------------------------------------------------------------------
+# Test that we can access the page using any of the other domains as well
+# Update the dns entry for iris-gaia-red.gaia-dmp.uk
+# iris-gaia-red.gaia-dmp.uk -> 128.232.227.160
+
+    ducktoken=$(getsecret 'devops.duckdns.token')
+    duckname=iris-gaia-red
+
+    curl "https://www.duckdns.org/update/${duckname:?}/${ducktoken:?}/${zeppelinip:?}"     
+   
+    > OK
+
+
+# -----------------------------------------------------
+# Test the HTTP endpoint using firefox.
+#[user@desktop]
+ 
+ 
+     firefox \
+        --new-window \
+        'https://iris-gaia-red.gaia-dmp.uk/'
+
+        # Success 
+        
+        
+# ------------------------------------------------------------------------
+# Ok it works, now set it back to what it was
+
+    ducktoken=$(getsecret 'devops.duckdns.token')
+    duckname=iris-gaia-red
+    zeppelinip=128.232.222.163
+    curl "https://www.duckdns.org/update/${duckname:?}/${ducktoken:?}/${zeppelinip:?}"     
+   
+
+# -----------------------------------------------------
+# Create our benchmark script.
+#[root@ansibler]
+
+cat > /tmp/run-benchmark.py << 'EOF'
+#!/bin/python3
+import sys
+from aglais_benchmark import AglaisBenchmarker
+
+try:
+
+    opts = [opt for opt in sys.argv[1:] if opt.startswith("-")]
+    args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
+
+    endpoint = args[0]
+    testconfig = args[1]
+    userlist = args[2]
+    usercount = int(args[3])
+    delaystart = int(args[4])
+    delaynotebook = int(args[5])
+
+except IndexError:
+
+    raise SystemExit(f"Usage: {sys.argv[0]} <Zepelin endpoint> <test config> <list of users> <number of users>")
+
+print("{")
+print(
+"""
+\"config\": {{
+    \"endpoint\":   \"{}\",
+    \"testconfig\": \"{}\",
+    \"userlist\":   \"{}\",
+    \"usercount\":  \"{}\",
+    \"delaystart\":  \"{}\",
+    \"delaynotebook\":  \"{}\"
+    }},
+\"output\":
+""".format(
+        endpoint,
+        testconfig,
+        userlist,
+        usercount,
+        delaystart,
+        delaynotebook
+        )
+    )
+
+print("---start---")
+AglaisBenchmarker(
+    testconfig,
+    userlist,
+    "/tmp/",
+    endpoint
+    ).run(
+        concurrent=True,
+        users=usercount,
+        delay_start=delaystart,
+        delay_notebook=delaynotebook
+        )
+print("---end---")
+print("}")
+EOF
+
+chmod 'a+x' /tmp/run-benchmark.py            
+
+
+
+# -----------------------------------------------------
+# Create test user config
+#[root@ansibler]
+
+# First, edit local ../common/users/test-users.yml  configuration to only create 1 user (Reyesfan1)
+    
+source /deployments/zeppelin/bin/create-user-tools.sh
+
+import-test-users
+
+	
+# -----------------------------------------------------
+# Run one quick test as a single user
+#[root@ansibler]
+
+    usercount=1
+
+    endpoint="https://iris-gaia-blue.gaia-dmp.uk"
+    testconfig=/deployments/zeppelin/test/config/quick.json
+    testusers=/tmp/test-users.json
+
+    delaystart=2
+    delaynotebook=2
+
+    /tmp/run-benchmark.py \
+        "${endpoint:?}" \
+        "${testconfig:?}" \
+        "${testusers:?}" \
+        "${usercount:?}" \
+        "${delaystart:?}" \
+        "${delaynotebook:?}" 
+
+
+[
+	[{
+		"name": "GaiaDMPSetup",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "FAST",
+			"elapsed": "40.32",
+			"expected": "45.00",
+			"percent": "-10.41",
+			"start": "2023-03-14T16:32:57.591124",
+			"finish": "2023-03-14T16:33:37.907845"
+		},
+		"logs": ""
+	}, {
+		"name": "Mean_proper_motions_over_the_sky",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "SLOW",
+			"elapsed": "123.36",
+			"expected": "55.00",
+			"percent": "124.29",
+			"start": "2023-03-14T16:33:39.910120",
+			"finish": "2023-03-14T16:35:43.266972"
+		},
+		"logs": ""
+	}, {
+		"name": "Source_counts_over_the_sky.json",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "SLOW",
+			"elapsed": "51.73",
+			"expected": "35.00",
+			"percent": "47.80",
+			"start": "2023-03-14T16:35:45.269285",
+			"finish": "2023-03-14T16:36:36.999958"
+		},
+		"logs": ""
+	}, {
+		"name": "Library_Validation.json",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "SLOW",
+			"elapsed": "11.30",
+			"expected": "10.00",
+			"percent": "12.99",
+			"start": "2023-03-14T16:36:39.002071",
+			"finish": "2023-03-14T16:36:50.301215"
+		},
+		"logs": ""
+	}]
+]
+
+# Success
+
+
+# -------------------------------
+# Try to renew the certificate
+# fedora@zeppelin
+
+sudo certbot renew --dry-run
+
+Challenge failed for domain dmp.gaia.ac.uk
+http-01 challenge for dmp.gaia.ac.uk
+Cleaning up challenges
+Attempting to renew cert (dmp.gaia.ac.uk) from /etc/letsencrypt/renewal/dmp.gaia.ac.uk.conf produced an unexpected error: Some challenges have failed.. Skipping.
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/gaia-dmp.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Cert not due for renewal, but simulating renewal for dry run
+Could not choose appropriate plugin: The manual plugin is not working; there may be problems with your existing configuration.
+The error was: PluginError('An authentication script must be provided with --manual-auth-hook when using the manual plugin non-interactively.')
+Attempting to renew cert (gaia-dmp.uk) from /etc/letsencrypt/renewal/gaia-dmp.uk.conf produced an unexpected error: The manual plugin is not working; there may be problems with your existing configuration.
+The error was: PluginError('An authentication script must be provided with --manual-auth-hook when using the manual plugin non-interactively.'). Skipping.
+All renewal attempts failed. The following certs could not be renewed:
+  /etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem (failure)
+  /etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem (failure)
+
+
+
+

--- a/notes/stv/20230314-test-deploy-wildcard-01.txt
+++ b/notes/stv/20230314-test-deploy-wildcard-01.txt
@@ -26,9 +26,8 @@
 
     Result:
 
-        Success.
-        New test deployment passes tests.
-
+        1 Failed.
+        (Renewal of certificates not working)
 
 
 

--- a/notes/stv/20230314-wildcard-cert-01.txt
+++ b/notes/stv/20230314-wildcard-cert-01.txt
@@ -109,7 +109,7 @@ curl "https://www.duckdns.org/update?domains=${duckname:?}&token=${ducktoken:?}&
 # user@dekstop
 
 
-# Copy cur certificate tarball certs.tar.gz
+# Copy current certificate tarball certs.tar.gz
 # user@dekstop
 
 pushd /home/stelios/Downloads/
@@ -144,10 +144,3 @@ exit
 scp /tmp/certs.tar.gz fedora@data.gaia-dmp.uk:/home/fedora/certs/20230314
 
 
-
-
-
-
-
-
-tar -czvf /tmp/certs.tar.gz /etc/letsencrypt/

--- a/notes/stv/20230314-wildcard-cert-01.txt
+++ b/notes/stv/20230314-wildcard-cert-01.txt
@@ -1,0 +1,153 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+# ------------------------------------------------------------
+# Run certbot to generate wildcard certificate for gaia-dmp.uk
+# user@desktop
+
+sudo certbot certonly --manual -d *.$DOMAIN -d $DOMAIN --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns-01 --server https://acme-v02.api.letsencrypt.org/directory --register-unsafely-without-email --rsa-key-size 4096
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+Plugins selected: Authenticator manual, Installer None
+Obtaining a new certificate
+Performing the following challenges:
+dns-01 challenge for gaia-dmp.uk
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Please deploy a DNS TXT record under the name
+_acme-challenge.gaia-dmp.uk with the following value:
+
+uMoIVHPU5fnHAj5V0i805oDCsi94RFF0xH3CVuEtZps
+
+Before continuing, verify the record is deployed.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Press Enter to Continue
+Waiting for verification...
+Cleaning up challenges
+
+IMPORTANT NOTES:
+ - Congratulations! Your certificate and chain have been saved at:
+   /etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem
+   Your key file has been saved at:
+   /etc/letsencrypt/live/gaia-dmp.uk/privkey.pem
+   Your cert will expire on 2023-06-12. To obtain a new or tweaked
+   version of this certificate in the future, simply run certbot
+   again. To non-interactively renew *all* of your certificates, run
+   "certbot renew"
+ - If you like Certbot, please consider supporting our work by:
+
+   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+   Donating to EFF:                    https://eff.org/donate-le
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+
+    source "${HOME:?}/aglais.env"
+
+    agcolour=blue
+    configname=zeppelin-54.86-spark-6.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+
+
+# ----------------------------
+# ACME challenge / TXT create
+# root@ansibler-blue
+ 
+ducktoken=$(getsecret 'devops.duckdns.token')
+duckname=aglais-live
+ducktext=uMoIVHPU5fnHAj5V0i805oDCsi94RFF0xH3CVuEtZps
+
+curl "https://www.duckdns.org/update?domains=${duckname:?}&token=${ducktoken:?}&txt=${ducktext:?}"
+
+> OK
+
+
+# ----------------------------
+# Combine certificates 
+# user@dekstop
+
+
+# Copy cur certificate tarball certs.tar.gz
+# user@dekstop
+
+pushd /home/stelios/Downloads/
+    scp fedora@data.gaia-dmp.uk:/home/fedora/certs/certs.tar.gz 
+    tar -xzvf  ~/Downloads/certs.tar.gz 
+
+
+# ----------------------------
+# Run meld and copy the certificate files we created for gaia-dmp.uk in the previous step to /home/Downloads/letsencrypt
+
+meld
+
+
+# ----------------------------
+# Create tar
+
+tar -czvf /tmp/certs.tar.gz letsencrypt/
+
+
+# ----------------------------
+# Create new directory to use for new cert tar on data mnode
+
+ssh fedora@data.gaia-dmp.uk
+  mkdir 20230314
+exit 
+
+
+# ----------------------------
+# Copy certs to data node
+# user@dekstop
+
+scp /tmp/certs.tar.gz fedora@data.gaia-dmp.uk:/home/fedora/certs/20230314
+
+
+
+
+
+
+
+
+tar -czvf /tmp/certs.tar.gz /etc/letsencrypt/

--- a/notes/stv/20230315-renewal-duckdns-plugin-01.txt
+++ b/notes/stv/20230315-renewal-duckdns-plugin-01.txt
@@ -1,0 +1,142 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+# Test certbot on the service created previously in 20230314-test-deploy-wildcard-01.txt
+
+
+
+# -------------------------------------
+# Install required libs
+# fedora@zeppelin
+
+sudo pip3 install certbot_dns_duckdns
+sudo pip3 install certbot-nginx
+
+# (Note we may need to uninstall previous versions of certbot if we get errors)
+
+
+DOMAIN=gaia-dmp.uk
+DUCKDNS_TOKEN= 
+
+# Generate certificate
+sudo certbot certonly   --non-interactive   --agree-tos  --rsa-key-size 4096 --register-unsafely-without-email   --preferred-challenges dns   --authenticator dns-duckdns   --dns-duckdns-token $DUCKDNS_TOKEN   --dns-duckdns-propagation-seconds 240  -d *.$DOMAIN -d $DOMAIN 
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+Requesting a certificate for *.gaia-dmp.uk and gaia-dmp.uk
+Waiting 120 seconds for DNS changes to propagate
+
+Successfully received certificate.
+Certificate is saved at: /etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem
+Key is saved at:         /etc/letsencrypt/live/gaia-dmp.uk/privkey.pem
+This certificate expires on 2023-06-12.
+These files will be updated when the certificate renews.
+
+NEXT STEPS:
+- The certificate will need to be renewed before it expires. Certbot can automatically renew the certificate in the background, but you may need to take steps to enable that functionality. See https://certbot.org/renewal-setup for instructions.
+
+
+
+# -------------------------------------
+# Try a --dry-run renewal
+# fedora@zeppelin
+
+sudo certbot renew     --staging  --dry-run
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/dmp.gaia.ac.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Simulating renewal of an existing certificate for dmp.gaia.ac.uk
+
+Certbot failed to authenticate some domains (authenticator: nginx). The Certificate Authority reported these problems:
+  Domain: dmp.gaia.ac.uk
+  Type:   unauthorized
+  Detail: 128.232.222.224: Invalid response from https://dmp.gaia.ac.uk/.well-known/acme-challenge/2I4udpXD4DUI2U9KMFytoEpu1rx8FID0JPV6qGVQrzk: 404
+
+...
+
+
+Certbot failed to authenticate some domains (authenticator: dns-duckdns). The Certificate Authority reported these problems:
+  Domain: gaia-dmp.uk
+  Type:   unauthorized
+  Detail: Incorrect TXT record "WzttfVPvsUKbwFkjmBxy6B4rVRtbjmxbyBcxcNEizc0" found at _acme-challenge.gaia-dmp.uk
+
+Hint: The Certificate Authority failed to verify the DNS TXT records created by --dns-duckdns. Ensure the above domains are hosted by this DNS provider, or try increasing --dns-duckdns-propagation-seconds (currently 120 seconds).
+
+
+...
+
+# -------------------------------------------
+# Try a renewal (gaia-dmp.uk) 
+# dmp.gaia.ac.uk renewal will only work when running on the live service 
+# fedora@zeppelin
+
+sudo certbot renew  --cert-name gaia-dmp.uk  
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/gaia-dmp.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Certificate not yet due for renewal
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+The following certificates are not due for renewal yet:
+  /etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem expires on 2023-06-12 (skipped)
+No renewals were attempted.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+# -------------------------------------------
+# Try a force renewal (gaia-dmp.uk) 
+# fedora@zeppelin
+
+sudo certbot renew  --cert-name gaia-dmp.uk  --force-renewal
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/gaia-dmp.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Renewing an existing certificate for *.gaia-dmp.uk and gaia-dmp.uk
+Waiting 120 seconds for DNS changes to propagate
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Congratulations, all renewals succeeded: 
+  /etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem (success)
+
+
+# So it looks like maybe we need the certificate created using duck-dns plugin rather than the manual one
+
+
+# ------------------------------------------------------
+# Copy over the certificates we've created to data node
+
+# Allow fedora to access letsencrypt folder
+sudo chown -R fedora:root /etc/letsencrypt
+
+# Create tar
+sudo tar -czvf /tmp/certs.tar.gz letsencrypt/
+
+# Copy to data node
+scp /tmp/certs.tar.gz fedora@data.gaia-dmp.uk:/home/fedora/certs/20230314
+
+
+

--- a/notes/stv/20230315-test-deploy-wildcard-01.txt
+++ b/notes/stv/20230315-test-deploy-wildcard-01.txt
@@ -1,0 +1,463 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+    Target:
+
+        Test deployment on blue
+       
+
+    Result:
+
+        Success.
+        New test deployment passes tests.
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+  
+    source "${HOME:?}/aglais.env"
+
+    agcolour=blue
+    configname=zeppelin-54.86-spark-6.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+        
+
+# -----------------------------------------------------
+# Deploy everything.
+#[root@ansibler]
+
+    time \
+        source /deployments/hadoop-yarn/bin/deploy.sh
+        
+	> 
+		
+	aglais:
+	  status:
+	    deployment:
+	      type: hadoop-yarn
+	      conf: zeppelin-54.86-spark-6.26.43
+	      name: iris-gaia-blue-20230315
+	      date: 20230315T115426
+	      hostname: zeppelin.gaia-dmp.uk
+	  spec:
+	    openstack:
+	      cloud:
+		base: arcus
+		name: iris-gaia-blue
+
+	real	66m59.298s
+	user	11m27.231s
+	sys	3m17.858s
+
+
+
+			
+# -----------------------------------------------------
+# Copy certificates from data server.
+#[root@ansibler]  
+      
+  scp -r fedora@data.gaia-dmp.uk:/home/fedora/certs/20230314/certs.tar.gz      /root/certs/
+   > certs.tar.gz                                                 100%   22KB 112.1KB/s   00:00    
+
+
+
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+	
+    /deployments/hadoop-yarn/bin/setup-ssl.sh \
+        "${cloudname:?}" \
+        "${configname:?}" \
+    | tee /tmp/setup-ssl.log
+
+
+	> 
+	
+
+TASK [Install certbot_dns_duckdns] *********************************************
+changed: [zeppelin] => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": true, "cmd": ["pip3", "install", "certbot_dns_duckdns"], "delta": "0:00:03.265354", "end": "2023-03-15 13:06:38.474583", "msg": "", "rc": 0, "start": "2023-03-15 13:06:35.209229", "stderr": "WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.\nERROR: pyopenssl 23.0.0 has requirement cryptography<40,>=38.0.0, but you'll have cryptography 2.6.1 which is incompatible.", "stderr_lines": ["WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.", "ERROR: pyopenssl 23.0.0 has requirement cryptography<40,>=38.0.0, but you'll have cryptography 2.6.1 which is incompatible."], "stdout": "Collecting certbot_dns_duckdns\n  Downloading https://files.pythonhosted.org/packages/2a/1f/a49d16e9ff84b4e90579b0f10b338d310ad8b10236bf08b40060fb7cba82/certbot_dns_duckdns-1.3-py3-none-any.whl\nCollecting certbot<3.0,>=1.18.0 (from certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/57/98/c5ab1ce27fe012b6c477bf7ff7edf9e366a02dd6fe055ffd103c55d38ad3/certbot-2.4.0-py3-none-any.whl (269kB)\nRequirement already satisfied: requests<3.0,>=2.20.0 in /usr/lib/python3.7/site-packages (from certbot_dns_duckdns) (2.22.0)\nCollecting dnspython<3.0,>=2.0.0 (from certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/12/86/d305e87555430ff4630d729420d97dece3b16efcbf2b7d7e974d11b0d86c/dnspython-2.3.0-py3-none-any.whl (283kB)\nCollecting ConfigArgParse>=0.9.3 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/af/cb/2a6620656f029b7b49c302853b433fac2c8eda9cbb5a3bc70b186b1b5b90/ConfigArgParse-1.5.3-py3-none-any.whl\nRequirement already satisfied: configobj>=5.0.6 in /usr/lib/python3.7/site-packages (from certbot<3.0,>=1.18.0->certbot_dns_duckdns) (5.0.6)\nRequirement already satisfied: cryptography>=2.5.0 in /usr/lib64/python3.7/site-packages (from certbot<3.0,>=1.18.0->certbot_dns_duckdns) (2.6.1)\nCollecting acme>=2.4.0 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/be/58/2b4dd178ccd77c0ade8ed9d33a3dcf916547810987e120eedd5a02a2c78a/acme-2.4.0-py3-none-any.whl (40kB)\nCollecting parsedatetime>=2.4 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl (42kB)\nCollecting pytz>=2019.3 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/2e/09/fbd3c46dce130958ee8e0090f910f1fe39e502cc5ba0aadca1e8a2b932e5/pytz-2022.7.1-py2.py3-none-any.whl (499kB)\nCollecting pyrfc3339 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/c1/7a/725f5c16756ec6211b1e7eeac09f469084595513917ea069bc023c40a5e2/pyRFC3339-1.1-py2.py3-none-any.whl\nCollecting setuptools>=41.6.0 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Using cached https://files.pythonhosted.org/packages/c3/9e/8a7ba2c9984a060daa6c6f9fff4d576b7ace3936239d6b771541eab972ed/setuptools-67.6.0-py3-none-any.whl\nRequirement already satisfied: distro>=1.0.1 in /usr/lib/python3.7/site-packages (from certbot<3.0,>=1.18.0->certbot_dns_duckdns) (1.4.0)\nCollecting josepy>=1.13.0 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/b0/95/111ee5954f4a607f77c46dbc1f482e1f5b440b48c93017e221e34f33ad51/josepy-1.13.0-py2.py3-none-any.whl\nRequirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python3.7/site-packages (from requests<3.0,>=2.20.0->certbot_dns_duckdns) (3.0.4)\nRequirement already satisfied: idna<2.9,>=2.5 in /usr/lib/python3.7/site-packages (from requests<3.0,>=2.20.0->certbot_dns_duckdns) (2.8)\nRequirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/lib/python3.7/site-packages (from requests<3.0,>=2.20.0->certbot_dns_duckdns) (1.25.3)\nRequirement already satisfied: asn1crypto>=0.21.0 in /usr/lib/python3.7/site-packages (from cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (0.24.0)\nRequirement already satisfied: six>=1.4.1 in /usr/lib/python3.7/site-packages (from cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (1.12.0)\nRequirement already satisfied: cffi!=1.11.3,>=1.8 in /usr/lib64/python3.7/site-packages (from cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (1.12.3)\nCollecting PyOpenSSL>=17.5.0 (from acme>=2.4.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns)\n  Downloading https://files.pythonhosted.org/packages/73/00/b78f9fae05bb1633f7209aa394fa0c3563ef760ab7f47ac37768bf4e4d78/pyOpenSSL-23.0.0-py3-none-any.whl (57kB)\nRequirement already satisfied: pycparser in /usr/lib/python3.7/site-packages (from cffi!=1.11.3,>=1.8->cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (2.14)\nInstalling collected packages: ConfigArgParse, PyOpenSSL, pytz, pyrfc3339, setuptools, josepy, acme, parsedatetime, certbot, dnspython, certbot-dns-duckdns\nSuccessfully installed ConfigArgParse-1.5.3 PyOpenSSL-23.0.0 acme-2.4.0 certbot-2.4.0 certbot-dns-duckdns-1.3 dnspython-2.3.0 josepy-1.13.0 parsedatetime-2.6 pyrfc3339-1.1 pytz-2022.7.1 setuptools-67.6.0", "stdout_lines": ["Collecting certbot_dns_duckdns", "  Downloading https://files.pythonhosted.org/packages/2a/1f/a49d16e9ff84b4e90579b0f10b338d310ad8b10236bf08b40060fb7cba82/certbot_dns_duckdns-1.3-py3-none-any.whl", "Collecting certbot<3.0,>=1.18.0 (from certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/57/98/c5ab1ce27fe012b6c477bf7ff7edf9e366a02dd6fe055ffd103c55d38ad3/certbot-2.4.0-py3-none-any.whl (269kB)", "Requirement already satisfied: requests<3.0,>=2.20.0 in /usr/lib/python3.7/site-packages (from certbot_dns_duckdns) (2.22.0)", "Collecting dnspython<3.0,>=2.0.0 (from certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/12/86/d305e87555430ff4630d729420d97dece3b16efcbf2b7d7e974d11b0d86c/dnspython-2.3.0-py3-none-any.whl (283kB)", "Collecting ConfigArgParse>=0.9.3 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/af/cb/2a6620656f029b7b49c302853b433fac2c8eda9cbb5a3bc70b186b1b5b90/ConfigArgParse-1.5.3-py3-none-any.whl", "Requirement already satisfied: configobj>=5.0.6 in /usr/lib/python3.7/site-packages (from certbot<3.0,>=1.18.0->certbot_dns_duckdns) (5.0.6)", "Requirement already satisfied: cryptography>=2.5.0 in /usr/lib64/python3.7/site-packages (from certbot<3.0,>=1.18.0->certbot_dns_duckdns) (2.6.1)", "Collecting acme>=2.4.0 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/be/58/2b4dd178ccd77c0ade8ed9d33a3dcf916547810987e120eedd5a02a2c78a/acme-2.4.0-py3-none-any.whl (40kB)", "Collecting parsedatetime>=2.4 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl (42kB)", "Collecting pytz>=2019.3 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/2e/09/fbd3c46dce130958ee8e0090f910f1fe39e502cc5ba0aadca1e8a2b932e5/pytz-2022.7.1-py2.py3-none-any.whl (499kB)", "Collecting pyrfc3339 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/c1/7a/725f5c16756ec6211b1e7eeac09f469084595513917ea069bc023c40a5e2/pyRFC3339-1.1-py2.py3-none-any.whl", "Collecting setuptools>=41.6.0 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Using cached https://files.pythonhosted.org/packages/c3/9e/8a7ba2c9984a060daa6c6f9fff4d576b7ace3936239d6b771541eab972ed/setuptools-67.6.0-py3-none-any.whl", "Requirement already satisfied: distro>=1.0.1 in /usr/lib/python3.7/site-packages (from certbot<3.0,>=1.18.0->certbot_dns_duckdns) (1.4.0)", "Collecting josepy>=1.13.0 (from certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/b0/95/111ee5954f4a607f77c46dbc1f482e1f5b440b48c93017e221e34f33ad51/josepy-1.13.0-py2.py3-none-any.whl", "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python3.7/site-packages (from requests<3.0,>=2.20.0->certbot_dns_duckdns) (3.0.4)", "Requirement already satisfied: idna<2.9,>=2.5 in /usr/lib/python3.7/site-packages (from requests<3.0,>=2.20.0->certbot_dns_duckdns) (2.8)", "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/lib/python3.7/site-packages (from requests<3.0,>=2.20.0->certbot_dns_duckdns) (1.25.3)", "Requirement already satisfied: asn1crypto>=0.21.0 in /usr/lib/python3.7/site-packages (from cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (0.24.0)", "Requirement already satisfied: six>=1.4.1 in /usr/lib/python3.7/site-packages (from cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (1.12.0)", "Requirement already satisfied: cffi!=1.11.3,>=1.8 in /usr/lib64/python3.7/site-packages (from cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (1.12.3)", "Collecting PyOpenSSL>=17.5.0 (from acme>=2.4.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns)", "  Downloading https://files.pythonhosted.org/packages/73/00/b78f9fae05bb1633f7209aa394fa0c3563ef760ab7f47ac37768bf4e4d78/pyOpenSSL-23.0.0-py3-none-any.whl (57kB)", "Requirement already satisfied: pycparser in /usr/lib/python3.7/site-packages (from cffi!=1.11.3,>=1.8->cryptography>=2.5.0->certbot<3.0,>=1.18.0->certbot_dns_duckdns) (2.14)", "Installing collected packages: ConfigArgParse, PyOpenSSL, pytz, pyrfc3339, setuptools, josepy, acme, parsedatetime, certbot, dnspython, certbot-dns-duckdns", "Successfully installed ConfigArgParse-1.5.3 PyOpenSSL-23.0.0 acme-2.4.0 certbot-2.4.0 certbot-dns-duckdns-1.3 dnspython-2.3.0 josepy-1.13.0 parsedatetime-2.6 pyrfc3339-1.1 pytz-2022.7.1 setuptools-67.6.0"]}
+
+TASK [Install certbot-nginx] ***************************************************
+fatal: [zeppelin]: FAILED! => {"changed": true, "cmd": ["pip3", "install", "certbot-nginx"], "delta": "0:00:00.218217", "end": "2023-03-15 13:06:40.476280", "msg": "non-zero return code", "rc": 1, "start": "2023-03-15 13:06:40.258063", "stderr": "Traceback (most recent call last):\n  File \"/usr/bin/pip3\", line 7, in <module>\n    from pip._internal import main\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/__init__.py\", line 40, in <module>\n    from pip._internal.cli.autocompletion import autocomplete\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/cli/autocompletion.py\", line 8, in <module>\n    from pip._internal.cli.main_parser import create_main_parser\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/cli/main_parser.py\", line 12, in <module>\n    from pip._internal.commands import (\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/commands/__init__.py\", line 6, in <module>\n    from pip._internal.commands.completion import CompletionCommand\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/commands/completion.py\", line 6, in <module>\n    from pip._internal.cli.base_command import Command\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/cli/base_command.py\", line 20, in <module>\n    from pip._internal.download import PipSession\n  File \"/usr/lib/python3.7/site-packages/pip/_internal/download.py\", line 15, in <module>\n    from pip._vendor import requests, six, urllib3\n  File \"/usr/lib/python3.7/site-packages/pip/_vendor/requests/__init__.py\", line 97, in <module>\n    from pip._vendor.urllib3.contrib import pyopenssl\n  File \"/usr/lib/python3.7/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py\", line 46, in <module>\n    import OpenSSL.SSL\n  File \"/usr/local/lib64/python3.7/site-packages/OpenSSL/__init__.py\", line 8, in <module>\n    from OpenSSL import SSL, crypto\n  File \"/usr/local/lib64/python3.7/site-packages/OpenSSL/SSL.py\", line 19, in <module>\n    from OpenSSL.crypto import (\n  File \"/usr/local/lib64/python3.7/site-packages/OpenSSL/crypto.py\", line 3261, in <module>\n    name=\"load_pkcs7_data\",\nTypeError: deprecated() got an unexpected keyword argument 'name'", "stderr_lines": ["Traceback (most recent call last):", "  File \"/usr/bin/pip3\", line 7, in <module>", "    from pip._internal import main", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/__init__.py\", line 40, in <module>", "    from pip._internal.cli.autocompletion import autocomplete", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/cli/autocompletion.py\", line 8, in <module>", "    from pip._internal.cli.main_parser import create_main_parser", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/cli/main_parser.py\", line 12, in <module>", "    from pip._internal.commands import (", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/commands/__init__.py\", line 6, in <module>", "    from pip._internal.commands.completion import CompletionCommand", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/commands/completion.py\", line 6, in <module>", "    from pip._internal.cli.base_command import Command", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/cli/base_command.py\", line 20, in <module>", "    from pip._internal.download import PipSession", "  File \"/usr/lib/python3.7/site-packages/pip/_internal/download.py\", line 15, in <module>", "    from pip._vendor import requests, six, urllib3", "  File \"/usr/lib/python3.7/site-packages/pip/_vendor/requests/__init__.py\", line 97, in <module>", "    from pip._vendor.urllib3.contrib import pyopenssl", "  File \"/usr/lib/python3.7/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py\", line 46, in <module>", "    import OpenSSL.SSL", "  File \"/usr/local/lib64/python3.7/site-packages/OpenSSL/__init__.py\", line 8, in <module>", "    from OpenSSL import SSL, crypto", "  File \"/usr/local/lib64/python3.7/site-packages/OpenSSL/SSL.py\", line 19, in <module>", "    from OpenSSL.crypto import (", "  File \"/usr/local/lib64/python3.7/site-packages/OpenSSL/crypto.py\", line 3261, in <module>", "    name=\"load_pkcs7_data\",", "TypeError: deprecated() got an unexpected keyword argument 'name'"], "stdout": "", "stdout_lines": []}
+
+
+
+# After some research looks like this is a compatibility issue with the libraries pyopenssl / cryptography
+# Solution, upgrade pip
+
+# i.e 
+
+sudo pip install --upgrade pip
+
+
+# Update Ansible script to upgrade pip and try again..
+# Change made in hadoop-yarn/ansible/29-install-pip-libs.yml
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+  
+    source "${HOME:?}/aglais.env"
+
+    agcolour=blue
+    configname=zeppelin-54.86-spark-6.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+        
+
+# -----------------------------------------------------
+# Deploy everything.
+#[root@ansibler]
+
+    time \
+        source /deployments/hadoop-yarn/bin/deploy.sh
+		
+		>
+
+		aglais:
+		  status:
+		    deployment:
+		      type: hadoop-yarn
+		      conf: zeppelin-54.86-spark-6.26.43
+		      name: iris-gaia-blue-20230315
+		      date: 20230315T140639
+		      hostname: zeppelin.gaia-dmp.uk
+		  spec:
+		    openstack:
+		      cloud:
+			base: arcus
+			name: iris-gaia-blue
+
+		real	57m23.427s
+		user	7m1.611s
+		sys	1m53.228s 
+
+
+# -----------------------------------------------------
+# Copy certificates from data server.
+#[root@ansibler]  
+      
+  scp -r fedora@data.gaia-dmp.uk:/home/fedora/certs/20230314/certs.tar.gz      /root/certs/
+   > Done 
+
+
+
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+	
+    /deployments/hadoop-yarn/bin/setup-ssl.sh \
+        "${cloudname:?}" \
+        "${configname:?}" \
+    | tee /tmp/setup-ssl.log
+
+
+# -----------------------------------------------------
+# Test the HTTPS endpoint using firefox.
+#[user@desktop]
+
+
+    firefox \
+        --new-window \
+        'https://iris-gaia-blue.gaia-dmp.uk/'
+
+        # Success
+        
+# -----------------------------------------------------
+# Test the HTTP endpoint using firefox.
+#[user@desktop]
+ 
+ 
+     firefox \
+        --new-window \
+        'https://iris-gaia-blue.gaia-dmp.uk/'
+
+        # Success / Redirected to HTTPS page
+        
+
+
+# -----------------------------------------------------
+# Create our benchmark script.
+#[root@ansibler]
+
+cat > /tmp/run-benchmark.py << 'EOF'
+#!/bin/python3
+import sys
+from aglais_benchmark import AglaisBenchmarker
+
+try:
+
+    opts = [opt for opt in sys.argv[1:] if opt.startswith("-")]
+    args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
+
+    endpoint = args[0]
+    testconfig = args[1]
+    userlist = args[2]
+    usercount = int(args[3])
+    delaystart = int(args[4])
+    delaynotebook = int(args[5])
+
+except IndexError:
+
+    raise SystemExit(f"Usage: {sys.argv[0]} <Zepelin endpoint> <test config> <list of users> <number of users>")
+
+print("{")
+print(
+"""
+\"config\": {{
+    \"endpoint\":   \"{}\",
+    \"testconfig\": \"{}\",
+    \"userlist\":   \"{}\",
+    \"usercount\":  \"{}\",
+    \"delaystart\":  \"{}\",
+    \"delaynotebook\":  \"{}\"
+    }},
+\"output\":
+""".format(
+        endpoint,
+        testconfig,
+        userlist,
+        usercount,
+        delaystart,
+        delaynotebook
+        )
+    )
+
+print("---start---")
+AglaisBenchmarker(
+    testconfig,
+    userlist,
+    "/tmp/",
+    endpoint
+    ).run(
+        concurrent=True,
+        users=usercount,
+        delay_start=delaystart,
+        delay_notebook=delaynotebook
+        )
+print("---end---")
+print("}")
+EOF
+
+chmod 'a+x' /tmp/run-benchmark.py            
+
+
+
+# -----------------------------------------------------
+# Create test user config
+#[root@ansibler]
+    
+source /deployments/zeppelin/bin/create-user-tools.sh
+
+import-test-users
+
+	
+# -----------------------------------------------------
+# Run one quick test as a single user
+#[root@ansibler]
+
+    usercount=1
+
+    endpoint="https://iris-gaia-blue.gaia-dmp.uk"
+    testconfig=/deployments/zeppelin/test/config/quick.json
+    testusers=/tmp/test-users.json
+
+    delaystart=2
+    delaynotebook=2
+
+    /tmp/run-benchmark.py \
+        "${endpoint:?}" \
+        "${testconfig:?}" \
+        "${testusers:?}" \
+        "${usercount:?}" \
+        "${delaystart:?}" \
+        "${delaynotebook:?}" 
+
+
+[
+	[{
+		"name": "GaiaDMPSetup",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "FAST",
+			"elapsed": "40.52",
+			"expected": "45.00",
+			"percent": "-9.97",
+			"start": "2023-03-15T19:03:17.009965",
+			"finish": "2023-03-15T19:03:57.525290"
+		},
+		"logs": ""
+	}, {
+		"name": "Mean_proper_motions_over_the_sky",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "SLOW",
+			"elapsed": "124.48",
+			"expected": "55.00",
+			"percent": "126.32",
+			"start": "2023-03-15T19:03:59.526256",
+			"finish": "2023-03-15T19:06:04.004377"
+		},
+		"logs": ""
+	}, {
+		"name": "Source_counts_over_the_sky.json",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "SLOW",
+			"elapsed": "53.66",
+			"expected": "35.00",
+			"percent": "53.33",
+			"start": "2023-03-15T19:06:06.006379",
+			"finish": "2023-03-15T19:06:59.670399"
+		},
+		"logs": ""
+	}, {
+		"name": "Library_Validation.json",
+		"result": "PASS",
+		"outputs": {
+			"valid": true
+		},
+		"messages": [],
+		"time": {
+			"result": "SLOW",
+			"elapsed": "12.47",
+			"expected": "10.00",
+			"percent": "24.71",
+			"start": "2023-03-15T19:07:01.673655",
+			"finish": "2023-03-15T19:07:14.144165"
+		},
+		"logs": ""
+	}]
+]
+# Success
+
+
+# -------------------------------
+# Try to renew the certificate
+# fedora@zeppelin
+
+sudo certbot renew --dry-run
+
+Challenge failed for domain dmp.gaia.ac.uk
+http-01 challenge for dmp.gaia.ac.uk
+Cleaning up challenges
+Attempting to renew cert (dmp.gaia.ac.uk) from /etc/letsencrypt/renewal/dmp.gaia.ac.uk.conf produced an unexpected error: Some challenges have failed.. Skipping.
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/gaia-dmp.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Cert not due for renewal, but simulating renewal for dry run
+Could not choose appropriate plugin: The manual plugin is not working; there may be problems with your existing configuration.
+The error was: PluginError('An authentication script must be provided with --manual-auth-hook when using the manual plugin non-interactively.')
+Attempting to renew cert (gaia-dmp.uk) from /etc/letsencrypt/renewal/gaia-dmp.uk.conf produced an unexpected error: The manual plugin is not working; there may be problems with your existing configuration.
+The error was: PluginError('An authentication script must be provided with --manual-auth-hook when using the manual plugin non-interactively.'). Skipping.
+All renewal attempts failed. The following certs could not be renewed:
+  /etc/letsencrypt/live/dmp.gaia.ac.uk/fullchain.pem (failure)
+  /etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem (failure)
+
+
+# ---------------------------------------------------
+# Update the certificate directories on the data node
+# fedora@data.gaia-dmp.uk
+
+pushd certs
+  mkdir 20230123
+  mv certs.tar.gz 20230123/
+  cp 20230123/certs.tar.gz .
+popd
+
+exit
+
+
+
+
+# -------------------------------------------
+# Try a force renewal (gaia-dmp.uk) 
+# fedora@zeppelin
+
+sudo certbot renew  --cert-name gaia-dmp.uk  --force-renewal
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/gaia-dmp.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Renewing an existing certificate for *.gaia-dmp.uk and gaia-dmp.uk
+Waiting 240 seconds for DNS changes to propagate
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Congratulations, all renewals succeeded: 
+/etc/letsencrypt/live/gaia-dmp.uk/fullchain.pem (success)
+


### PR DESCRIPTION
PR to enable wildcard certificate / Single certificate for all gaia-dmp.uk domains
Likely that there may be corrections needed, open to recommendations on changing improving anything for this

- Changes to Ansible scripts (new domains.yml file / Multiple nginx servers / using duckdns certbot)
- Notes on creating & storing new certificate
- Notes on testing HTTPS with new certs