### PR TITLE
Enable Maintenance mode for GDMP

### DIFF
--- a/deployments/aglais/bin/lock-zeppelin.sh
+++ b/deployments/aglais/bin/lock-zeppelin.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo mv /etc/nginx/conf.d/zeppelin.conf /etc/nginx/conf.d/zeppelin.backup
+sudo mv /etc/nginx/conf.d/maintenance.backup /etc/nginx/conf.d/maintenance.conf
+sudo service nginx restart

--- a/deployments/aglais/bin/lock-zeppelin.sh
+++ b/deployments/aglais/bin/lock-zeppelin.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo mv /etc/nginx/conf.d/zeppelin.conf /etc/nginx/conf.d/zeppelin.backup
 sudo mv /etc/nginx/conf.d/maintenance.backup /etc/nginx/conf.d/maintenance.conf
+sudo mv /etc/nginx/conf.d/zeppelin.conf /etc/nginx/conf.d/zeppelin.backup
 sudo service nginx restart

--- a/deployments/aglais/bin/unlock-zeppelin.sh
+++ b/deployments/aglais/bin/unlock-zeppelin.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo mv /etc/nginx/conf.d/maintenance.conf /etc/nginx/conf.d/maintenance.backup
+sudo mv /etc/nginx/conf.d/zeppelin.backup /etc/nginx/conf.d/zeppelin.conf
+sudo service nginx restart

--- a/notes/stv/20230619-test-lock.txt
+++ b/notes/stv/20230619-test-lock.txt
@@ -1,0 +1,218 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Test Locking an instance of GDMP
+        
+    Result:
+
+        Success.
+       
+
+
+# -----------------------------------------------------
+# Check which cloud is currently live.
+#[user@desktop]
+
+    ssh fedora@live.gaia-dmp.uk \
+        '
+        date
+        hostname
+        '
+        
+	> iris-gaia-green-20230308-zeppelin
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    #
+    # Live is green, selecting blue for the deployment.
+    #
+
+    source "${HOME:?}/aglais.env"
+
+    agcolour=blue
+    configname=zeppelin-26.43-spark-3.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+    >   ....
+
+
+
+# -----------------------------------------------------
+# Deploy everything.
+#[root@ansibler]
+
+    time \
+        source /deployments/hadoop-yarn/bin/deploy.sh
+        
+        ...
+
+> Done
+
+
+	
+# -----------------------------------------------------
+# Create users    
+#[root@ansibler]
+
+    source /deployments/zeppelin/bin/create-user-tools.sh
+
+    import-test-users
+
+
+
+..
+
+,
+"shirouser": 
+{
+"name": "Evison",
+"type": "test",
+"role": "user",
+"password": "..",
+"passhash": "..",
+"hashhash": "..",
+"debug": {
+    "script": "create-shiro-user.sh",
+    "result": "PASS",
+    "messages": ["PASS: passgen done","PASS: hashpass done","PASS: database INSERT done"]
+    }
+}
+,
+"notebooks": 
+
+
+	
+# -----------------------------------------------------
+# Lock instance for maintenance
+
+source /opt/aglais/bin/lock-zeppelin.sh
+
+
+curl -v https://iris-gaia-blue.gaia-dmp.uk/#/?ref=%2F
+*   Trying 128.232.226.248:443...
+* TCP_NODELAY set
+* Connected to iris-gaia-blue.gaia-dmp.uk (128.232.226.248) port 443 (#0)
+* ALPN, offering h2
+* ALPN, offering http/1.1
+* successfully set certificate verify locations:
+*   CAfile: /etc/ssl/certs/ca-certificates.crt
+  CApath: /etc/ssl/certs
+* TLSv1.3 (OUT), TLS handshake, Client hello (1):
+* TLSv1.3 (IN), TLS handshake, Server hello (2):
+* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
+* TLSv1.3 (IN), TLS handshake, Certificate (11):
+* TLSv1.3 (IN), TLS handshake, CERT verify (15):
+* TLSv1.3 (IN), TLS handshake, Finished (20):
+* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
+* TLSv1.3 (OUT), TLS handshake, Finished (20):
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
+* ALPN, server accepted to use http/1.1
+* Server certificate:
+*  subject: CN=*.gaia-dmp.uk
+*  start date: Jun 14 03:14:29 2023 GMT
+*  expire date: Sep 12 03:14:28 2023 GMT
+*  subjectAltName: host "iris-gaia-blue.gaia-dmp.uk" matched cert's "*.gaia-dmp.uk"
+*  issuer: C=US; O=Let's Encrypt; CN=R3
+*  SSL certificate verify ok.
+> GET / HTTP/1.1
+> Host: iris-gaia-blue.gaia-dmp.uk
+> User-Agent: curl/7.68.0
+> Accept: */*
+> 
+* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
+* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
+* old SSL session ID is stale, removing
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 200 OK
+< Server: nginx/1.18.0
+< Date: Mon, 19 Jun 2023 15:00:02 GMT
+< Content-Type: text/html
+< Content-Length: 1227
+< Last-Modified: Mon, 19 Jun 2023 10:41:19 GMT
+< Connection: keep-alive
+< ETag: "649030cf-4cb"
+< Accept-Ranges: bytes
+< 
+<!DOCTYPE html>
+<html>
+<head>
+      	<title>Service is down for maintenance</title>
+        <style>
+               	body {
+                      	font-family: Arial, sans-serif;
+                        background-color: #f2f2f2;
+                }
+                .container {
+                        max-width: 800px;
+                        margin: 0 auto;
+                        padding: 50px;
+                        background-color: #fff;
+                        box-shadow: 0px 0px 10px #ccc;
+                        text-align: center;
+                }
+                h1 {
+                    	font-size: 3em;
+                        margin-bottom: 30px;
+                }
+                p {
+                   	font-size: 1.2em;
+                        margin-bottom: 20px;
+                }
+        </style>
+</head>
+<body>
+      	<div class="container">
+                <h1>Service is down for maintenance</h1>
+                <p>We apologize for the inconvenience, but our service is currently undergoing maintenance.</p>
+                <p>Please check back soon, or contact us at <a href="mailto:gaiadmp-support@roe.ac.uk">gaiadmp-support@roe.ac.uk</a> for more information.</p>
+        </div>
+</body>
+</html>
+
+* Connection #0 to host iris-gaia-blue.gaia-dmp.uk left intact
+
+

--- a/notes/stv/20230619-test-lock.txt
+++ b/notes/stv/20230619-test-lock.txt
@@ -215,4 +215,12 @@ curl -v https://iris-gaia-blue.gaia-dmp.uk/#/?ref=%2F
 
 * Connection #0 to host iris-gaia-blue.gaia-dmp.uk left intact
 
+	
+# -----------------------------------------------------
+# Unlock instance 
 
+source /opt/aglais/bin/unlock-zeppelin.sh
+
+curl https://iris-gaia-blue.gaia-dmp.uk/
+
+> Zeppelin UI


### PR DESCRIPTION
# Description of PR:

Add capability to lock down an instance of GDMP for maintenance. Displays a maintenance page instead of Zeppelin UI if enabled

## Related Issues

Closes #1086
Closes #986 
Closes #704 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

https://github.com/stvoutsin/gaia-dmp/blob/e0e7921b5893b054adf2d5408ed81bdc728b7517/notes/stv/20230619-test-lock.txt

**Test Configuration**

* agcolour = blue
* configname = zeppelin-26.43-spark-3.26.43