### PR TITLE
HDBSCAN library upgrade

### DIFF
--- a/deployments/common/pip/requirements.txt
+++ b/deployments/common/pip/requirements.txt
@@ -11,7 +11,7 @@ astropy==4.2.1
 astroquery==0.4.1
 scikit-learn==0.24.2
 joblib==1.1.0
-hdbscan==0.8.27
+hdbscan==0.8.31
 pyvo==1.1
 pyarrow==8.0.0
 koalas==1.8.2

--- a/notes/stv/20230725-test-deploy-01.txt
+++ b/notes/stv/20230725-test-deploy-01.txt
@@ -193,3 +193,104 @@ user	8m31.645s
 sys	2m10.157s
 
 # No error messages in package installation 
+
+
+
+# -----------------------------------------------------
+# Start NGINX    
+#[root@ansibler]
+
+    source /deployments/hadoop-yarn/bin/start-nginx.sh 
+
+    > Done	
+
+	
+# -----------------------------------------------------
+# Create users    
+#[root@ansibler]
+
+    source /deployments/zeppelin/bin/create-user-tools.sh
+
+    import-test-users
+    
+    > Done        
+        
+# -----------------------------------------------------
+# Run Tests
+#[root@ansibler]
+
+git clone https://github.com/stvoutsin/aglais-testing
+pushd aglais-testing/
+  pip install -r pip-requirements
+  python3 setup.py install
+popd
+
+pushd aglais-testing/gdmp_benchmark
+  python3 gdmp_benchmark.py --zeppelin_url http://128.232.226.136 --usercount 1 --notebook_config /deployments/zeppelin/test/config/quick.json --user_config /tmp/test-users.json --delay_start 0 --delay_notebook 0
+
+[{
+    "name": "GaiaDMPSetup",
+    "result": "SUCCESS",
+    "outputs": {
+        "valid": true
+    },
+    "messages": [],
+    "time": {
+        "result": "FAST",
+        "elapsed": "47.00",
+        "percent": "-6.00",
+        "start": "2023-07-26T11:34:12.398541",
+        "finish": "2023-07-26T11:34:59.415792"
+    },
+    "logs": ""
+},
+ {
+    "name": "Mean_proper_motions_over_the_sky",
+    "result": "SUCCESS",
+    "outputs": {
+        "valid": true
+    },
+    "messages": [],
+    "time": {
+        "result": "FAST",
+        "elapsed": "125.00",
+        "percent": "0.00",
+        "start": "2023-07-26T11:34:59.415885",
+        "finish": "2023-07-26T11:37:04.450915"
+    },
+    "logs": ""
+},
+ {
+    "name": "Source_counts_over_the_sky.json",
+    "result": "SUCCESS",
+    "outputs": {
+        "valid": true
+    },
+    "messages": [],
+    "time": {
+        "result": "SLOW",
+        "elapsed": "59.00",
+        "percent": "7.27",
+        "start": "2023-07-26T11:37:04.451259",
+        "finish": "2023-07-26T11:38:04.397479"
+    },
+    "logs": ""
+},
+ {
+    "name": "Library_Validation.json",
+    "result": "SUCCESS",
+    "outputs": {
+        "valid": true
+    },
+    "messages": [],
+    "time": {
+        "result": "FAST",
+        "elapsed": "9.00",
+        "percent": "-40.00",
+        "start": "2023-07-26T11:38:04.397585",
+        "finish": "2023-07-26T11:38:13.539211"
+    },
+    "logs": ""
+}]
+
+

--- a/notes/stv/20230725-test-deploy-01.txt
+++ b/notes/stv/20230725-test-deploy-01.txt
@@ -1,0 +1,195 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Test hbscan upgrade
+
+    Result:
+
+        Success.
+       
+
+
+# -----------------------------------------------------
+# Check which cloud is currently live.
+#[user@desktop]
+
+    ssh fedora@live.gaia-dmp.uk \
+        '
+        date
+        hostname
+        '
+        
+	> iris-gaia-green-20230308-zeppelin
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    #
+    # Live is green, selecting red for the deployment.
+    #
+
+    source "${HOME:?}/aglais.env"
+
+    agcolour=red
+    configname=zeppelin-54.86-spark-6.26.43
+
+    agproxymap=3000:3000
+    clientname=ansibler-${agcolour}
+    cloudname=iris-gaia-${agcolour}
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name     "${clientname:?}" \
+        --hostname "${clientname:?}" \
+        --publish  "${agproxymap:?}" \
+        --env "cloudname=${cloudname:?}" \
+        --env "configname=${configname:?}" \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK:?}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.07.25 \
+        bash
+
+    >   ....
+
+
+TASK [Copy pip requirements file into tmp] *************************************
+changed: [master01]
+changed: [worker03]
+changed: [worker04]
+changed: [worker02]
+changed: [worker01]
+changed: [worker05]
+changed: [worker06]
+changed: [zeppelin]
+
+TASK [Install the required Python packages] ************************************
+changed: [worker03]
+changed: [worker04]
+changed: [worker01]
+changed: [worker02]
+changed: [master01]
+changed: [zeppelin]
+changed: [worker06]
+changed: [worker05]
+
+
+...
+
+# data.gaia-dmp.uk:22 SSH-2.0-OpenSSH_8.0
+# data.gaia-dmp.uk:22 SSH-2.0-OpenSSH_8.0
+# data.gaia-dmp.uk:22 SSH-2.0-OpenSSH_8.0
+Warning: Permanently added the ECDSA host key for IP address '128.232.222.153' to the list of known hosts.
+
+Number of files: 583 (reg: 432, dir: 151)
+Number of created files: 583 (reg: 432, dir: 151)
+Number of deleted files: 0
+Number of regular files transferred: 432
+Total file size: 193.82M bytes
+Total transferred file size: 193.82M bytes
+Literal data: 193.82M bytes
+Matched data: 0 bytes
+File list size: 50.94K
+File list generation time: 0.003 seconds
+File list transfer time: 0.000 seconds
+Total bytes sent: 9.05K
+Total bytes received: 193.92M
+
+sent 9.05K bytes  received 193.92M bytes  55.41M bytes/sec
+total size is 193.82M  speedup is 1.00
+
+Number of files: 1 (reg: 1)
+Number of created files: 1 (reg: 1)
+Number of deleted files: 0
+Number of regular files transferred: 1
+Total file size: 103.15K bytes
+Total transferred file size: 103.15K bytes
+Literal data: 103.15K bytes
+Matched data: 0 bytes
+File list size: 87
+File list generation time: 0.001 seconds
+File list transfer time: 0.000 seconds
+Total bytes sent: 43
+Total bytes received: 103.31K
+
+sent 43 bytes  received 103.31K bytes  206.71K bytes/sec
+total size is 103.15K  speedup is 1.00
+Zeppelin stop                                              [  OK  ]
+Zeppelin start                                             [  OK  ]
+----
+Updating DuckDNS record
+OK
+----
+Collecting git+https://github.com/wfau/aglais-testing@v0.2.6
+  Cloning https://github.com/wfau/aglais-testing (to revision v0.2.6) to /tmp/pip-req-build-m38vmbua
+  Running command git clone --filter=blob:none -q https://github.com/wfau/aglais-testing /tmp/pip-req-build-m38vmbua
+  Running command git checkout -q bc9b9787b5b6225e11df5a4ef0272bcec660a44e
+  Resolved https://github.com/wfau/aglais-testing to commit bc9b9787b5b6225e11df5a4ef0272bcec660a44e
+  Preparing metadata (setup.py) ... done
+Collecting zdairi@ git+https://github.com/stvoutsin/zdairi
+  Cloning https://github.com/stvoutsin/zdairi to /tmp/pip-install-1w1y4h2h/zdairi_76b1b8ba13f24ce3aa05e5ba6be1b712
+  Running command git clone --filter=blob:none -q https://github.com/stvoutsin/zdairi /tmp/pip-install-1w1y4h2h/zdairi_76b1b8ba13f24ce3aa05e5ba6be1b712
+  Resolved https://github.com/stvoutsin/zdairi to commit a26cdc80af3c8e339036928105a762ab79af96e0
+  Preparing metadata (setup.py) ... done
+Requirement already satisfied: simplejson in /usr/local/lib64/python3.10/site-packages (from aglais-benchmark==0.1.1) (3.17.6)
+Requirement already satisfied: requests in /usr/local/lib/python3.10/site-packages (from zdairi@ git+https://github.com/stvoutsin/zdairi->aglais-benchmark==0.1.1) (2.28.1)
+Requirement already satisfied: PyYAML in /usr/lib64/python3.10/site-packages (from zdairi@ git+https://github.com/stvoutsin/zdairi->aglais-benchmark==0.1.1) (6.0)
+Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/site-packages (from requests->zdairi@ git+https://github.com/stvoutsin/zdairi->aglais-benchmark==0.1.1) (3.3)
+Requirement already satisfied: charset-normalizer<3,>=2 in /usr/local/lib/python3.10/site-packages (from requests->zdairi@ git+https://github.com/stvoutsin/zdairi->aglais-benchmark==0.1.1) (2.1.0)
+Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/site-packages (from requests->zdairi@ git+https://github.com/stvoutsin/zdairi->aglais-benchmark==0.1.1) (2022.6.15)
+Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.10/site-packages (from requests->zdairi@ git+https://github.com/stvoutsin/zdairi->aglais-benchmark==0.1.1) (1.26.10)
+Using legacy 'setup.py install' for aglais-benchmark, since package 'wheel' is not installed.
+Using legacy 'setup.py install' for zdairi, since package 'wheel' is not installed.
+Installing collected packages: zdairi, aglais-benchmark
+    Running setup.py install for zdairi ... done
+    Running setup.py install for aglais-benchmark ... done
+Successfully installed aglais-benchmark-0.1.1 zdairi-0.7.3
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+
+
+aglais:
+  status:
+    deployment:
+      type: hadoop-yarn
+      conf: zeppelin-54.86-spark-6.26.43
+      name: iris-gaia-red-20230725
+      date: 20230725T081543
+      hostname: zeppelin.gaia-dmp.uk
+  spec:
+    openstack:
+      cloud:
+        base: arcus
+        name: iris-gaia-red
+
+real	51m55.193s
+user	8m31.645s
+sys	2m10.157s
+
+# No error messages in package installation 


### PR DESCRIPTION
# Description of PR:

Upgrade hdbscan library version, as what is currently on main fails to install. Potentially due a downstream upgrade of some other 3rd party library.

## Related Issues
Closes:  https://github.com/wfau/gaia-dmp/issues/1199

# How Has This Been Tested?

https://github.com/wfau/gaia-dmp/compare/master...stvoutsin:gaia-dmp:issue/hdbcscan-fix?expand=1#diff-520c658458d984c9f6c55e3e3d9215edc71a33e9c952f8c0b9033bb1057fc027


**Test Configuration**

* agcolour = red
* configname = zeppelin-54.86-spark-6.26.43


