### PR TITLE
Add healthchecker as a cronjob

### DIFF
--- a/notes/stv/20231016-healthchecker-cron.txt
+++ b/notes/stv/20231016-healthchecker-cron.txt
@@ -1,0 +1,108 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2023, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Setup and test healthchecker as a cronjob for GDMP
+
+
+    Result:
+
+        Success.
+        
+        
+# -----------------------------------------------------
+# Download and setup testing lib
+#[fedora@iris-gaia-data-20220411-gitstore]
+
+sudo su
+cd /opt
+
+git clone https://github.com/wfau/aglais-testing
+
+pushd aglais-testing/
+
+    python3.8 -m pip install -r pip-requirements 
+    python3.8 setup.py install
+
+popd
+
+
+# -----------------------------------------------------
+# Create test-user config file:
+nano /opt/aglais-testing/gdmp_benchmark/test-users.json
+
+    {
+      "users": [
+        {
+          "username": "",
+          "shirouser": {
+            "name": "",
+            "password": ""
+          }
+        }
+      ]
+    }
+
+
+# -----------------------------------------------------
+# Run test that fails / causes an exception
+# https://raw.githubusercontent.com/wfau/aglais-testing/main/config/notebooks/notebooks-failcheck.json 
+
+
+sudo python3.8 /opt/aglais-testing/gdmp_benchmark/gdmp_benchmark.py --zeppelin_url https://dmp.gaia.ac.uk --usercount 1 --notebook_config https://raw.githubusercontent.com/wfau/aglais-testing/main/config/notebooks/notebooks-failcheck.json --user_config /tmp/test-users.json --delay_start 0 --delay_notebook 0 --slack_webhook ${SLACK_WEBHOOK:?}
+
+# Check Slack #system-alerts:
+
+# New message
+
+[{'name': 'pi_quick', 'result': 'ERROR', 'outputs': {'valid': True}, 'messages': [], 'logs': 'Py4JJavaError: An error occurred while calling z:org.apache.spark.api.python.PythonRDD.collectAndServe.\n: org.apache.spark.SparkException: Job aborted due to stage failure: Task 68 in stage 0.0 failed 4 times, most recent failure: Lost task 68.3 in stage 0.0 (TID 159) (worker03 executor 4): org.apache.spark.api.python.PythonException: Traceback (most recent call last):\n  File "/var/hadoop/data/usercache/SVoutsinas/appcache/application_1695721742886_0042/c
+
+...
+xhon.PythonRDD.collectAndServe.\\n\', JavaObject id=o111), <traceback object at 0x7f7374bec320>)', 'time': {'result': SLOW, 'elapsed': '28.00', 'percent': '180.00', 'start': '2023-10-12T23:25:25.403996', 'finish': '2023-10-12T23:25:54.215164'}}]
+---end---
+
+	
+
+
+
+# ------------------------------------------------------
+# Run quick tests and make sure we don't get any alerts
+#  (assuming it runs successfully)
+
+sudo python3.8 /opt/aglais-testing/gdmp_benchmark/gdmp_benchmark.py --zeppelin_url https://dmp.gaia.ac.uk --usercount 1 --notebook_config https://raw.githubusercontent.com/wfau/gaia-dmp/master/deployments/zeppelin/test/config/quick.json --user_config /tmp/test-users.json --delay_start 0 --delay_notebook 0 --slack_webhook ${SLACK_WEBHOOK:?}
+
+
+# Check Slack #system-alerts:
+
+.. 
+
+  # No new messages
+	
+	
+#---------------------------------------------
+# Setup cron job
+
+0 2 * * * sudo python3.8 /opt/aglais-testing/gdmp_benchmark/gdmp_benchmark.py --zeppelin_url https://dmp.gaia.ac.uk --usercount 1 --notebook_config https://raw.githubusercontent.com/wfau/gaia-dmp/master/deployments/zeppelin/test/config/quick.json --user_config /opt/aglais-testing/gdmp_benchmark/test-users.json --delay_start 0 --delay_notebook 0 --slack_webhook ${SLACK_WEBHOOK:?}
+
+
+


### PR DESCRIPTION
Uses the benchmark tool:
https://github.com/wfau/aglais-testing

Runs a quick test once a day, and send out an alert in Slack (#system-alerts on gaia-dmp workspace if any notebook fails.