### PR TITLE
Upgrade version of testing lib that we target

### DIFF
--- a/deployments/zeppelin/test/config/basic.json
+++ b/deployments/zeppelin/test/config/basic.json
@@ -2,43 +2,43 @@
 "notebooks" : [
            {
               "name" : "GaiaDMPSetup",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/GaiaDMP_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/GaiaDMP_validation.json",
               "totaltime" : 50,
               "results" : []
            },
            {
               "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
               "totaltime" : 120,
               "results" : []
            },
            {
               "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Source_counts_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Source_counts_over_the_sky.json",
               "totaltime" : 55,
               "results" : []
            },
            {
               "name" : "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
               "totaltime" : 650,
               "results" : []
            },
            {
               "name" : "Working_with_cross_matched_surveys",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Working_with_cross_matched_surveys.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Working_with_cross_matched_surveys.json",
               "totaltime" : 190,
               "results" : []
            },
            {
               "name" : "Working_with_Gaia_XP_spectra.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Working_with_Gaia_XP_spectra.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Working_with_Gaia_XP_spectra.json",
               "totaltime" : 190,
               "results" : []
            },
            {
               "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/Library_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/Library_validation.json",
               "totaltime" : 10,
               "results" : []
            }

--- a/deployments/zeppelin/test/config/full.json
+++ b/deployments/zeppelin/test/config/full.json
@@ -2,49 +2,49 @@
 "notebooks" : [
            {
               "name" : "GaiaDMPSetup",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/GaiaDMP_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/GaiaDMP_validation.json",
               "totaltime" : 50,
               "results" : []
            },
            {
               "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
               "totaltime" : 125,
               "results" : []
            },
            {
               "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Source_counts_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Source_counts_over_the_sky.json",
               "totaltime" : 55,
               "results" : []
            },
            {
               "name" : "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
               "totaltime" : 650,
               "results" : []
            },
            {
               "name" : "Working_with_cross_matched_surveys",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Working_with_cross_matched_surveys.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Working_with_cross_matched_surveys.json",
               "totaltime" : 190,
               "results" : []
            },
            {
               "name" : "Working_with_Gaia_XP_spectra.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Working_with_Gaia_XP_spectra.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Working_with_Gaia_XP_spectra.json",
               "totaltime" : 190,
               "results" : []
            },
            {
               "name" : "QC_cuts_dev.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/QC_cuts_dev.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/QC_cuts_dev.json",
               "totaltime" : 10100,
               "results" : []
            },
            {
               "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/Library_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/Library_validation.json",
               "totaltime" : 10,
               "results" : []
            }

--- a/deployments/zeppelin/test/config/quick-healthchecker.json
+++ b/deployments/zeppelin/test/config/quick-healthchecker.json
@@ -2,25 +2,25 @@
 "notebooks" : [
            {
               "name" : "GaiaDMPSetup",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/GaiaDMP_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/GaiaDMP_validation.json",
               "totaltime" : 3,
               "results" : []
            },
            {
               "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
               "totaltime" : 125,
               "results" : []
            },
            {
               "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Source_counts_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Source_counts_over_the_sky.json",
               "totaltime" : 55,
               "results" : []
            },
            {
               "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/Library_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/Library_validation.json",
               "totaltime" : 10,
               "results" : []
            }

--- a/deployments/zeppelin/test/config/quick.json
+++ b/deployments/zeppelin/test/config/quick.json
@@ -2,25 +2,25 @@
 "notebooks" : [
            {
               "name" : "GaiaDMPSetup",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/GaiaDMP_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/GaiaDMP_validation.json",
               "totaltime" : 50,
               "results" : []
            },
            {
               "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
               "totaltime" : 125,
               "results" : []
            },
            {
               "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/public_examples/Source_counts_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/public_examples/Source_counts_over_the_sky.json",
               "totaltime" : 55,
               "results" : []
            },
            {
               "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/bc9b9787b5b6225e11df5a4ef0272bcec660a44e/notebooks/Library_validation.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/de63a27120e7fc4a2faeb75c2cfd43c1bfcdfd32/notebooks/Library_validation.json",
               "totaltime" : 10,
               "results" : []
            }


### PR DESCRIPTION
Libs have been updated, but we are still pointing to previous release of testing lib that contains our test notebooks.
Have updated the library validation notebook, and this PR changes the version to target the new updated release