### PR TITLE
Update pyvo version to 1.5.1

### DIFF
--- a/deployments/common/pip/requirements.txt
+++ b/deployments/common/pip/requirements.txt
@@ -12,7 +12,7 @@ astroquery==0.4.6
 scikit-learn==1.3.2
 joblib==1.3.2
 hdbscan==0.8.33
-pyvo==1.1
+pyvo==1.5.1
 pyarrow==14.0.1
 GaiaXPy==2.1.0
 git+https://github.com/wfau/gaiadmpsetup@v0.1.5


### PR DESCRIPTION
Pyvo in the current main branch is broken 
Issue:
https://github.com/wfau/gaia-dmp/issues/1314

With this upgrade the import works again:

Deploy new GaiaDMP with version on main

ssh into Zeppelin node:

Try to import pyvo in python3

    python3

    import pyvo

        Traceback (most recent call last):
        File "", line 1, in
        File "/usr/local/lib/python3.11/site-packages/pyvo/init.py", line 37, in
        from . import registry
        File "/usr/local/lib/python3.11/site-packages/pyvo/registry/init.py", line 7, in
        from . import regtap
        File "/usr/local/lib/python3.11/site-packages/pyvo/registry/regtap.py", line 19, in
        from ..dal import scs, sia, ssa, sla, tap, query as dalq
        File "/usr/local/lib/python3.11/site-packages/pyvo/dal/init.py", line 2, in
        from .sia import search as imagesearch
        File "/usr/local/lib/python3.11/site-packages/pyvo/dal/sia.py", line 39, in
        from .query import DALResults, DALQuery, DALService, Record
        File "/usr/local/lib/python3.11/site-packages/pyvo/dal/query.py", line 47, in
        from ..utils.decorators import stream_decode_content
        File "/usr/local/lib/python3.11/site-packages/pyvo/utils/decorators.py", line 4, in
        from astropy.utils.decorators import wraps
        ImportError: cannot import name 'wraps' from 'astropy.utils.decorators'
Upgrade pyvo and try again

    pip install pyvo==1.5.1

    python3

    import pyvo
  Success