### PR TITLE
Correct expected duration for Gaia Spectra notebook

### DIFF
--- a/deployments/zeppelin/test/config/basic.json
+++ b/deployments/zeppelin/test/config/basic.json
@@ -33,7 +33,7 @@
            {
               "name" : "Working_with_Gaia_XP_spectra.json",
               "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/a4e05c8b9ebe0372c431322d7d66b969dfabb9e1/notebooks/public_examples/Working_with_Gaia_XP_spectra.json",
-              "totaltime" : 190,
+              "totaltime" : 6000,
               "results" : []
            },
            {

--- a/deployments/zeppelin/test/config/full.json
+++ b/deployments/zeppelin/test/config/full.json
@@ -27,7 +27,7 @@
            {
               "name" : "Working_with_cross_matched_surveys",
               "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/a4e05c8b9ebe0372c431322d7d66b969dfabb9e1/notebooks/public_examples/Working_with_cross_matched_surveys.json",
-              "totaltime" : 190,
+              "totaltime" : 6000,
               "results" : []
            },
            {


### PR DESCRIPTION
Not sure why, but it seems that the duration for the Gaia Spectra is wrong. It takes 1 hour and a half on the live system